### PR TITLE
Filtrování procesů dle loginů

### DIFF
--- a/search/src/java/cz/incad/Kramerius/views/ProcessesViewObject.java
+++ b/search/src/java/cz/incad/Kramerius/views/ProcessesViewObject.java
@@ -672,6 +672,18 @@ public class ProcessesViewObject implements Initializable {
         return "";
     }
 
+    public String getLoginNameLike() {
+        if (this.filter != null) {
+            List<Tripple> tripples = this.filter.getTripples();
+            for (Tripple tripple : tripples) {
+                if (tripple.getName().equals("loginname") && tripple.getOp().equals(SQLFilter.Op.LIKE)) {
+                    return this.filter.getFormattedValue(tripple);
+                }
+            }
+        }
+        return "";
+    }
+
     public String getNameLike() {
         if (this.filter != null) {
             List<Tripple> tripples = this.filter.getTripples();

--- a/search/src/java/labels.properties
+++ b/search/src/java/labels.properties
@@ -430,6 +430,7 @@ administrator.processes.filter.state=State
 administrator.processes.filter.batch=Batch state
 
 administrator.processes.filter.pname=Name contains
+administrator.processes.filter.loginname=Login name contains
 administrator.processes.filter.plannedafter=Planned after
 
 administrator.processes.filter.plannedbefore=Planned before

--- a/search/src/java/labels_cs.properties
+++ b/search/src/java/labels_cs.properties
@@ -419,6 +419,7 @@ administrator.processes.filter.label=Pou\u017Eit\u00FD filtr
 administrator.processes.filter.state=Stav
 administrator.processes.filter.batch=D\u00E1vkov\u00FD stav
 administrator.processes.filter.pname=Jm\u00E9no procesu obsahuje
+administrator.processes.filter.loginname=P\u0159ihla\u0161ovac\u00ED jm\u00E9no obsahuje
 administrator.processes.filter.plannedafter=Napl\u00E1nov\u00E1no po
 administrator.processes.filter.plannedbefore=Napl\u00E1nov\u00E1no p\u0159ed
 administrator.processes.filter.startedafter=Spu\u0161t\u011Bno po

--- a/search/web/inc/admin/_processes_data.jsp
+++ b/search/web/inc/admin/_processes_data.jsp
@@ -324,6 +324,12 @@ $(document).ready(function(){
 
             <tr>
                 <td><span class="ui-icon ui-icon-triangle-1-e"></span></td>
+                <td><label for="filter-state"><view:msg>administrator.processes.filter.loginname</view:msg>:</label></td>
+                <td><input type="text" name="loginname" class="filter-vals like" value="${processView.loginNameLike}"></input></td>
+            </tr>
+
+            <tr>
+                <td><span class="ui-icon ui-icon-triangle-1-e"></span></td>
                 <td><label for="filter-state"><view:msg>administrator.processes.filter.pname</view:msg>:</label></td>
                 <td><input type="text" name="name" class="filter-vals like" value="${processView.nameLike}"></input></td>
             </tr>


### PR DESCRIPTION
U krameriusndktest.mzk.cz se nám točí velké množství procesů pod loginem transformačního modulu. Když si tam pustím proces pod svým jménem a nezaznamenám si jeho identifikátor, tak se mi špatně ten proces dohledává.

Přidal jsem tedy do filtrů vyhledávací pole "Přihlašovací jméno obsahuje:"
