### PR TITLE
Remote debugging for processes can be enabled in properties

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/processes/impl/AbstractLRProcessImpl.java
+++ b/common/src/main/java/cz/incad/kramerius/processes/impl/AbstractLRProcessImpl.java
@@ -145,6 +145,10 @@ public abstract class AbstractLRProcessImpl implements LRProcess{
 				command.add(jpParam);
 			}
 
+            if (configuration.getConfiguration().getBoolean("indexer.remoteDebug", false) ) {
+                LOGGER.info("Process is waiting for the debugger to attach");
+                command.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + configuration.getConfiguration().getInt("indexer.port", 8001));
+            }
 			command.add("-D"+ProcessStarter.MAIN_CLASS_KEY+"="+this.definition.getMainClass());
 			command.add("-D"+ProcessStarter.UUID_KEY+"="+this.uuid);
             command.add("-D"+ProcessStarter.TOKEN_KEY+"="+this.getGroupToken());

--- a/indexer/src/res/configuration.properties
+++ b/indexer/src/res/configuration.properties
@@ -11,7 +11,11 @@ IndexBase=${solrHost}
 #property ur\u00c4\u008duje, jestli je po ukon\u00c4\u008den\u00c3\u00ad indexace vol\u00c3\u00a1n softCommit(false) nebo hardCommit(true)
 indexer.isSoftCommit=false
 
-#form\u00c3\u00a1t indexovan\u00c3\u00bdch FOXML soubor\u00c5\u00af
+#zapíná remote debugging na procesech. Pokud není debugger připojen je proces pozastavený.
+indexer.remoteDebug=false
+indexer.port=8001
+
+#formát indexovaných FOXML souborů
 FOXMLFormat=info:fedora/fedora-system:FOXML-1.1
 
 # Oddelovac v pripade vicenasobnych pid parametru


### PR DESCRIPTION
Často máme ve Fedoře repository něco tak rozbitého, že v Krameriu neprojde reindexace ani export foxml. Ne vždy je jasné z logu Krameria co se přesně stalo, potom samotný proces debugujeme.

Když se nastaví v konfiguračním souboru indexer.properties toto:

indexer.remoteDebug=true
indexer.port=8001

Je proces pozastaven a spuštěn až po připojení dubugovacího nástroje (upozornění na to je vypisováno do catalina.out). Hodilo by se mi, kdyby to bylo začleněno přímo do distribuce.