### PR TITLE
API - audio datastreams secured

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/security/SecuredFedoraAccessImpl.java
+++ b/common/src/main/java/cz/incad/kramerius/security/SecuredFedoraAccessImpl.java
@@ -204,7 +204,10 @@ public class SecuredFedoraAccessImpl implements FedoraAccess {
     static boolean isDefaultSecuredStream(String streamName) {
         return FedoraUtils.IMG_FULL_STREAM.equals(streamName)
                 || FedoraUtils.IMG_PREVIEW_STREAM.equals(streamName)
-                || FedoraUtils.TEXT_OCR_STREAM.equals(streamName);
+                || FedoraUtils.TEXT_OCR_STREAM.equals(streamName)
+                || FedoraUtils.MP3_STREAM.equals(streamName)
+                || FedoraUtils.WAV_STREAM.equals(streamName)
+                || FedoraUtils.OGG_STREAM.equals(streamName);
     }
 
     @Override

--- a/common/src/main/java/cz/incad/kramerius/utils/FedoraUtils.java
+++ b/common/src/main/java/cz/incad/kramerius/utils/FedoraUtils.java
@@ -47,6 +47,10 @@ public class FedoraUtils {
     public static final String DC_STREAM = "DC";
     public static final String BIBLIO_MODS_STREAM = "BIBLIO_MODS";
     public static final String TEXT_OCR_STREAM = "TEXT_OCR";
+    public static final String MP3_STREAM = "MP3";
+    public static final String OGG_STREAM = "OGG";
+    public static final String WAV_STREAM = "WAV";
+
     
     public static final String POLICY_STREAM="POLICY";
     


### PR DESCRIPTION
Audiodatastreamy mají být chráněné stejně jako velký obrázek nebo OCR. Tato oprava to řeší. 

Až se bude řešit https://github.com/ceskaexpedice/kramerius/issues/109, tak prosím pozor na regrese (ačkoliv si myslím, že AudioProxy servlet to řeší)