### PR TITLE
CORS filter

### DIFF
--- a/search/src/java/cz/incad/Kramerius/CORSFilter.java
+++ b/search/src/java/cz/incad/Kramerius/CORSFilter.java
@@ -1,0 +1,33 @@
+package cz.incad.Kramerius;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class CORSFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+        HttpServletResponse response = (HttpServletResponse) res;
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Headers", "x-requested-with");
+        chain.doFilter(req, res);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/search/web/WEB-INF/web.xml
+++ b/search/web/WEB-INF/web.xml
@@ -16,6 +16,16 @@
         <url-pattern>/lr</url-pattern>
     </filter-mapping>
 
+    <filter>
+        <filter-name>cors</filter-name>
+        <filter-class>cz.incad.Kramerius.CORSFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>cors</filter-name>
+        <url-pattern>/api/*</url-pattern>
+        <url-pattern>/zoomify/*</url-pattern>
+    </filter-mapping>
+
     <!-- mod_proxy filter; doesnt work in krameriusdemo don't know why (logout doesn't work)
     <filter>
         <filter-name>mod_proxy</filter-name>


### PR DESCRIPTION
Na základě těchto hlaviček prohlížeče povolí Cross-origin resource sharing. Umožní to provozovat javascriptového klienta i mimo doménu na které je API.