### PR TITLE
Zelené čtverečky i u nepřístupného dokumentu

### DIFF
--- a/search/web/inc/details/thumbs.jsp
+++ b/search/web/inc/details/thumbs.jsp
@@ -204,7 +204,7 @@
             img.load(function(){$(elem).removeClass('inactive')});
             $(elem).append(img);
             var dost = $('<div>', {class: 'dost'});
-            var p = isPrivate(uuid);
+            var p = isPrivate(ext_uuid);
             if(p && !policyPublic){
                 dost.append('<img src="img/lock.png" />');
             }else if(!p && policyPublic){


### PR DESCRIPTION
Může se stát, že zelený čtvereček se zobrazí i u nepřístupného doumentu. Takový případ je možné vidět zde (jenom dnes, večer to přehodím na zámečky, u kterých se problém nevyskytuje)
http://krameriusndktest.mzk.cz/search/i.jsp?pid=uuid:ed1a5170-e8e4-11e4-b834-005056827e51

Přikládám opravu řešící tento problém (vznikla s pomocí @honza-rychtar).