### PR TITLE
api - split authors in array

### DIFF
--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/FeederSolrAuthorDecorate.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/FeederSolrAuthorDecorate.java
@@ -38,7 +38,7 @@ public class FeederSolrAuthorDecorate extends AbstractFeederDecorator {
                 doc = this.memo.askForIndexDocument(pid);
             }
             if (doc != null) {
-                List<String> authors = SOLRUtils.array(doc, "dc.creator", String.class);
+                List<String> authors = SOLRUtils.narray(doc, "dc.creator", String.class);
                 if (authors != null && !authors.isEmpty()) {
                     jsonObject.put("author", authors);
                 }


### PR DESCRIPTION
Maličká oprava dělení autorů v API

původně:
"author":["Smoljak, LadislavCimrman, Jára daSvěrák, ZdeněkDivadlo Járy Cimrmana"]
V poli author jsou všichni autoři zřetězení do jednoho řetězce bez mezer.

správně to má být (a po opravě skutečně je):
"author":["Smoljak, Ladislav", "Cimrman, Jára da", "Svěrák, Zdeněk", "Divadlo Járy Cimrmana"]
