### PR TITLE
Opravení audio streamů

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/audio/AudioStreamForwardUtils.java
+++ b/common/src/main/java/cz/incad/kramerius/audio/AudioStreamForwardUtils.java
@@ -43,9 +43,8 @@ public class AudioStreamForwardUtils {
     
     
     
-    public static ResponseBuilder GET(HttpServletRequest request,
+    public static ResponseBuilder GET(AudioStreamId id, HttpServletRequest request,
             ResponseBuilder builder, SolrAccess solrAccess, User user, IsActionAllowed actionAllowed, RepositoryUrlManager urlManager) throws IOException {
-        AudioStreamId id = AudioStreamId.fromPathInfo(request.getPathInfo());
         LOGGER.info(id.toString());
         if (canBeRead(id.getPid(), solrAccess, user, actionAllowed)) {
             try {
@@ -68,11 +67,8 @@ public class AudioStreamForwardUtils {
     
     }
     
-    public static void GET(HttpServletRequest request,
+    public static void GET(AudioStreamId id, HttpServletRequest request,
             HttpServletResponse response, SolrAccess solrAccess, User user, IsActionAllowed actionAllowed, RepositoryUrlManager urlManager) throws IOException, ServletException {
-        //TODO: tune logging levels (staci vetsinou FINE)
-        LOGGER.log(Level.INFO, "GET {0}", request.getPathInfo());
-        AudioStreamId id = AudioStreamId.fromPathInfo(request.getPathInfo());
         LOGGER.info(id.toString());
         if (canBeRead(id.getPid(), solrAccess, user, actionAllowed)) {
             try {
@@ -93,10 +89,8 @@ public class AudioStreamForwardUtils {
         }
     }
 
-    public static void HEAD(HttpServletRequest request,
+    public static void HEAD(AudioStreamId id, HttpServletRequest request,
             HttpServletResponse response, SolrAccess solrAccess, User user, IsActionAllowed actionAllowed, RepositoryUrlManager urlManager) throws IOException, ServletException {
-        LOGGER.log(Level.INFO, "HEAD {0}", request.getPathInfo());
-        AudioStreamId id = AudioStreamId.fromPathInfo(request.getPathInfo());
         LOGGER.info(id.toString());
         if (canBeRead(id.getPid(),solrAccess, user, actionAllowed)) {
             try {
@@ -117,10 +111,8 @@ public class AudioStreamForwardUtils {
         }
     }
 
-    public static ResponseBuilder HEAD(HttpServletRequest request,
+    public static ResponseBuilder HEAD(AudioStreamId id, HttpServletRequest request,
             ResponseBuilder builder, SolrAccess solrAccess, User user, IsActionAllowed actionAllowed, RepositoryUrlManager urlManager) throws IOException {
-        LOGGER.log(Level.INFO, "HEAD {0}", request.getPathInfo());
-        AudioStreamId id = AudioStreamId.fromPathInfo(request.getPathInfo());
         LOGGER.info(id.toString());
         if (canBeRead(id.getPid(),solrAccess, user, actionAllowed)) {
             try {

--- a/common/src/main/java/cz/incad/kramerius/audio/AudioStreamId.java
+++ b/common/src/main/java/cz/incad/kramerius/audio/AudioStreamId.java
@@ -33,7 +33,7 @@ public class AudioStreamId implements Serializable {
     private final String pid;
     private final AudioFormat format;
 
-    private AudioStreamId(String pid, AudioFormat format) {
+    public AudioStreamId(String pid, AudioFormat format) {
         this.pid = pid;
         this.format = format;
     }

--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/item/ItemResource.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/item/ItemResource.java
@@ -4,7 +4,9 @@ import com.google.inject.*;
 import com.google.inject.name.*;
 
 import cz.incad.kramerius.*;
+import cz.incad.kramerius.audio.AudioFormat;
 import cz.incad.kramerius.audio.AudioStreamForwardUtils;
+import cz.incad.kramerius.audio.AudioStreamId;
 import cz.incad.kramerius.audio.urlMapping.RepositoryUrlManager;
 import cz.incad.kramerius.rest.api.exceptions.*;
 import cz.incad.kramerius.rest.api.k5.client.*;
@@ -21,7 +23,6 @@ import net.sf.json.*;
 
 import org.w3c.dom.*;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
@@ -136,7 +137,8 @@ public class ItemResource {
                         HttpServletRequest request = this.requestProvider.get();
                         User user = this.userProvider.get();
 
-                        ResponseBuilder builder = AudioStreamForwardUtils.HEAD(request, responseBuilder, solrAccess, user, this.isActionAllowed, urlManager);
+                        AudioStreamId audioStreamId = new AudioStreamId(pid, AudioFormat.valueOf(dsid));
+                        ResponseBuilder builder = AudioStreamForwardUtils.HEAD(audioStreamId, request, responseBuilder, solrAccess, user, this.isActionAllowed, urlManager);
                         return builder.build();
                         
                     } else {
@@ -206,8 +208,8 @@ public class ItemResource {
 
                         HttpServletRequest request = this.requestProvider.get();
                         User user = this.userProvider.get();
-
-                        ResponseBuilder builder = AudioStreamForwardUtils.GET(request, responseBuilder, solrAccess, user, this.isActionAllowed, urlManager);
+                        AudioStreamId audioStreamId = new AudioStreamId(pid, AudioFormat.valueOf(dsid));
+                        ResponseBuilder builder = AudioStreamForwardUtils.GET(audioStreamId, request, responseBuilder, solrAccess, user, this.isActionAllowed, urlManager);
                         return builder.build();
                         
                     } else {

--- a/search/src/java/cz/incad/Kramerius/audio/servlet/AudioProxyServlet.java
+++ b/search/src/java/cz/incad/Kramerius/audio/servlet/AudioProxyServlet.java
@@ -91,7 +91,7 @@ public class AudioProxyServlet extends GuiceServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        AudioStreamForwardUtils.GET(request, response, this.solrAccess, this.userProvider.get(),this.actionAllowed, this.urlManager);
+        AudioStreamForwardUtils.GET(AudioStreamId.fromPathInfo(request.getPathInfo()), request, response, this.solrAccess, this.userProvider.get(),this.actionAllowed, this.urlManager);
     }
 
     /**
@@ -105,7 +105,7 @@ public class AudioProxyServlet extends GuiceServlet {
      */
     @Override
     protected void doHead(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        AudioStreamForwardUtils.HEAD(request, response,this.solrAccess, this.userProvider.get(),this.actionAllowed, this.urlManager);
+        AudioStreamForwardUtils.HEAD(AudioStreamId.fromPathInfo(request.getPathInfo()), request, response,this.solrAccess, this.userProvider.get(),this.actionAllowed, this.urlManager);
     }
 
     /**


### PR DESCRIPTION
V snapshot verzi byly rozbité audiostreamy:

viz http://kramerius.mzk.cz/search/api/v5.0/item/uuid:03c9b89b-868b-4b71-b76e-11098965a732/streams/MP3

Stávalo se to protože request.getPathInfo vracelo při volání přes api NULL. Přikládám opravu.
