### PR TITLE
IIIF Image API 2.0 servlet

### DIFF
--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/item/decorators/display/ZoomDecorate.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/item/decorators/display/ZoomDecorate.java
@@ -93,6 +93,9 @@ public class ZoomDecorate extends AbstractDisplayDecorate {
                         String appUrl = ApplicationURL.applicationURL(this.requestProvider.get())
                               .toString() + (zoomType.equals("zoomify") ? "/zoomify/" : "/deepZoom/");
                     	jsonObject.put("zoom", zoom(pid, zoomType, appUrl));
+                        String iiifUrl = ApplicationURL.applicationURL(this.requestProvider.get())
+                                .toString() + "/iiif/";
+                        jsonObject.put("iiif", iiifUrl + pid);
                     }
                 }
             }

--- a/search/src/java/cz/incad/Kramerius/AbstractImageServlet.java
+++ b/search/src/java/cz/incad/Kramerius/AbstractImageServlet.java
@@ -234,22 +234,26 @@ public abstract class AbstractImageServlet extends GuiceServlet {
         InputStream inputStream = null;
         try {
             HttpURLConnection con = (HttpURLConnection) RESTHelper.openConnection(urlString, "", "");
-            
-            inputStream = con.getInputStream();
-            String contentType = con.getContentType();
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            copyStreams(inputStream, bos);
-            copyStreams(new ByteArrayInputStream(bos.toByteArray()),
-                    resp.getOutputStream());
+            int responseCode = con.getResponseCode();
+            resp.setStatus(responseCode);
+            if (responseCode == 200) {
+                inputStream = con.getInputStream();
+                String contentType = con.getContentType();
 
-            resp.setContentType(contentType);
-            String headerFiled = con.getHeaderField("Cache-Control");
-            String lamodif = con.getHeaderField("Last-Modified");
-            
-            resp.setHeader("Cache-Control", headerFiled);
-            resp.setHeader("Last-Modified", lamodif);
-            
-            resp.setHeader("Access-Control-Allow-Origin", "*");
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                copyStreams(inputStream, bos);
+                copyStreams(new ByteArrayInputStream(bos.toByteArray()),
+                        resp.getOutputStream());
+
+                resp.setContentType(contentType);
+                String headerFiled = con.getHeaderField("Cache-Control");
+                String lamodif = con.getHeaderField("Last-Modified");
+
+
+                resp.setHeader("Cache-Control", headerFiled);
+                resp.setHeader("Last-Modified", lamodif);
+                resp.setHeader("Access-Control-Allow-Origin", "*");
+            }
             
             
         } finally {

--- a/search/src/java/cz/incad/Kramerius/imaging/IiifServlet.java
+++ b/search/src/java/cz/incad/Kramerius/imaging/IiifServlet.java
@@ -1,0 +1,119 @@
+package cz.incad.Kramerius.imaging;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+import cz.incad.Kramerius.AbstractImageServlet;
+import cz.incad.kramerius.FedoraAccess;
+import cz.incad.kramerius.ObjectPidsPath;
+import cz.incad.kramerius.SolrAccess;
+import cz.incad.kramerius.security.IsActionAllowed;
+import cz.incad.kramerius.security.SecuredActions;
+import cz.incad.kramerius.security.User;
+import cz.incad.kramerius.utils.RESTHelper;
+import cz.incad.kramerius.utils.RelsExtHelper;
+import cz.incad.kramerius.utils.imgs.KrameriusImageSupport;
+import org.apache.commons.io.IOUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.xpath.XPathExpressionException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.net.HttpURLConnection;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.util.StringTokenizer;
+import java.util.logging.Level;
+
+/**
+ * Created by rumanekm on 5.8.15.
+ */
+public class IiifServlet extends AbstractImageServlet {
+
+
+
+    @Inject
+    private SolrAccess solrAccess;
+
+    @Inject
+    private IsActionAllowed actionAllowed;
+
+    @Inject
+    private Provider<User> userProvider;
+
+    @Inject
+    @Named("securedFedoraAccess")
+    protected transient FedoraAccess fedoraAccess;
+
+    static java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(IiifServlet.class.getName());
+
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String requestURL = req.getRequestURL().toString();
+        String zoomUrl = DeepZoomServlet.disectZoom(requestURL);
+        StringTokenizer tokenizer = new StringTokenizer(zoomUrl, "/");
+        String pid = tokenizer.nextToken();
+
+        //unescape PID
+        pid = URLDecoder.decode(pid, "UTF-8");
+
+        if (!pid.matches("uuid:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        ObjectPidsPath[] paths = solrAccess.getPath(pid);
+        boolean permited = false;
+        for (ObjectPidsPath pth : paths) {
+            permited = this.actionAllowed.isActionAllowed(userProvider.get(), SecuredActions.READ.getFormalName(), pid, null, pth);
+            if (permited) break;
+        }
+
+        if (permited) {
+            try {
+                StringBuffer url = new StringBuffer(RelsExtHelper.getRelsExtTilesUrl(pid, this.fedoraAccess));
+                while (tokenizer.hasMoreTokens()) {
+                    String nextToken = tokenizer.nextToken();
+                    url.append("/" + nextToken);
+                    if ("info.json".equals(nextToken)) {
+                        resp.setContentType("application/ld+json");
+                        resp.setCharacterEncoding("UTF-8");
+                        HttpURLConnection con = (HttpURLConnection) RESTHelper.openConnection(url.toString(), "", "");
+                        InputStream inputStream = con.getInputStream();
+                        String json = IOUtils.toString(inputStream, Charset.defaultCharset());
+                        JSONObject object = new JSONObject(json);
+                        String urlRequest = req.getRequestURL().toString();
+                        object.put("@id", urlRequest.substring(0, urlRequest.lastIndexOf('/')));
+                        PrintWriter out = resp.getWriter();
+                        out.print(object.toString());
+                        out.flush();
+                        return;
+                    }
+                }
+                copyFromImageServer(url.toString(), req, resp);
+            } catch (XPathExpressionException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage());
+            } catch (JSONException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage());
+            }
+        } else {
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN);
+        }
+    }
+
+    @Override
+    public KrameriusImageSupport.ScalingMethod getScalingMethod() {
+        return null;
+    }
+
+    @Override
+    public boolean turnOnIterateScaling() {
+        return false;
+    }
+}

--- a/search/web/WEB-INF/web.xml
+++ b/search/web/WEB-INF/web.xml
@@ -24,6 +24,7 @@
         <filter-name>cors</filter-name>
         <url-pattern>/api/*</url-pattern>
         <url-pattern>/zoomify/*</url-pattern>
+        <url-pattern>/iiif/*</url-pattern>
     </filter-mapping>
 
     <!-- mod_proxy filter; doesnt work in krameriusdemo don't know why (logout doesn't work)
@@ -176,6 +177,11 @@
     <servlet>
         <servlet-name>zoomifyServlet</servlet-name>
         <servlet-class>cz.incad.Kramerius.imaging.ZoomifyServlet</servlet-class>
+    </servlet>
+
+    <servlet>
+        <servlet-name>iiifServlet</servlet-name>
+        <servlet-class>cz.incad.Kramerius.imaging.IiifServlet</servlet-class>
     </servlet>
 
 	<!-- private content servlet -->
@@ -388,6 +394,11 @@
     <servlet-mapping>
         <servlet-name>zoomifyServlet</servlet-name>
         <url-pattern>/zoomify/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>iiifServlet</servlet-name>
+        <url-pattern>/iiif/*</url-pattern>
     </servlet-mapping>
 
 	<servlet-mapping>


### PR DESCRIPTION
Servlet, který propouští IIIF požadavky na imageserver, viz specifikace http://iiif.io/api/image/2.0/. Protokol je otevřenou alternativou k dlaždicím Zoomify.

[link na validaci API](http://iiif.io/api/image/validator/results.html?server=http%3A%2F%2Fkrameriustest.mzk.cz%2Fsearch%2Fiiif%2F&prefix=&identifier=uuid%3A891ee7f6-42dc-42ae-8b97-475e30dca18d&version=2.0&level=1&id_squares=on&info_json=on&id_basic=on&id_error_escapedslash=on&id_error_unescaped=on&id_escaped=on&id_error_random=on&region_error_random=on&region_pixels=on&size_region=on&size_error_random=on&size_ch=on&size_wc=on&size_percent=on&rot_error_random=on&quality_error_random=on&format_jpg=on&format_error_random=on&jsonld=on&baseurl_redirect=on&cors=on)

Červené požadavky, které neprochází jsou způsobené neúplnou implementací v IIPImage (ale nemá to vliv na funkci IIIF prohlížečky).