### PR TITLE
fix .jpg přípony při importu z k3 formátu

### DIFF
--- a/import-cmdtool/src/main/java/com/qbizm/kramerius/imptool/poc/convertor/BaseConvertor.java
+++ b/import-cmdtool/src/main/java/com/qbizm/kramerius/imptool/poc/convertor/BaseConvertor.java
@@ -16,6 +16,7 @@ import cz.incad.kramerius.utils.conf.KConfiguration;
 import cz.incad.kramerius.utils.imgs.ImageMimeType;
 import cz.incad.kramerius.utils.imgs.KrameriusImageSupport;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.log4j.Logger;
@@ -720,10 +721,19 @@ public abstract class BaseConvertor {
                         String tilesPrefix = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerTilesURLPrefix");
                         String imagesPrefix = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerImagesURLPrefix");
                         String suffix = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerSuffix.big");
-                        cl.setREF(imagesPrefix + "/"+PathEncoder.encPath(getConfig().getContract()+"/"+pageFile.getName())+suffix);
-                        //Adjust RELS-EXT
-                        String suffixTiles = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerSuffix.tiles");
-                        re.addRelation(RelsExt.TILES_URL,tilesPrefix + "/"+PathEncoder.encPath(getConfig().getContract()+"/"+pageFile.getName())+ suffixTiles,true);
+
+                        if (KConfiguration.getInstance().getConfiguration().getBoolean("convert.imageServerSuffix.removeFilenameExtensions", false)) {
+                            String pageFileNameWithoutExtension = FilenameUtils.removeExtension(pageFile.getName());
+                            cl.setREF(imagesPrefix + "/" + PathEncoder.encPath(getConfig().getContract() + "/" + pageFileNameWithoutExtension) + suffix);
+                            //Adjust RELS-EXT
+                            String suffixTiles = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerSuffix.tiles");
+                            re.addRelation(RelsExt.TILES_URL, tilesPrefix + "/" + PathEncoder.encPath(getConfig().getContract() + "/" + pageFileNameWithoutExtension) + suffixTiles, true);
+                        } else {
+                            cl.setREF(imagesPrefix + "/" + PathEncoder.encPath(getConfig().getContract() + "/" + pageFile.getName()) + suffix);
+                            //Adjust RELS-EXT
+                            String suffixTiles = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerSuffix.tiles");
+                            re.addRelation(RelsExt.TILES_URL, tilesPrefix + "/" + PathEncoder.encPath(getConfig().getContract() + "/" + pageFile.getName()) + suffixTiles, true);
+                        }
                     }   else{
                         String externalPrefix = KConfiguration.getInstance().getConfiguration().getString("convert.externalStreamsUrlPrefix");
                         if (externalPrefix!= null&& !"".equals(externalPrefix)){
@@ -831,7 +841,12 @@ public abstract class BaseConvertor {
                 }else{
                     String imagesPrefix = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerImagesURLPrefix");
                     String suffix = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerSuffix.thumb");
-                    cl.setREF(imagesPrefix + "/"+PathEncoder.encPath(getConfig().getContract()+"/"+filename)+suffix);
+                    if (KConfiguration.getInstance().getConfiguration().getBoolean("convert.imageServerSuffix.removeFilenameExtensions", false)) {
+                        String pageFileNameWithoutExtension = FilenameUtils.removeExtension(filename);
+                        cl.setREF(imagesPrefix + "/" + PathEncoder.encPath(getConfig().getContract() + "/" + pageFileNameWithoutExtension + suffix));
+                    } else {
+                        cl.setREF(imagesPrefix + "/" + PathEncoder.encPath(getConfig().getContract() + "/" + filename) + suffix);
+                    }
                 }
                 cl.setTYPE("URL");
                 version.setContentLocation(cl);
@@ -905,7 +920,12 @@ public abstract class BaseConvertor {
                 }else{
                     String imagesPrefix = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerImagesURLPrefix");
                     String suffix = KConfiguration.getInstance().getConfiguration().getString("convert.imageServerSuffix.preview");
-                    cl.setREF(imagesPrefix +"/"+PathEncoder.encPath(getConfig().getContract()+"/"+filename)+suffix);
+                    if (KConfiguration.getInstance().getConfiguration().getBoolean("convert.imageServerSuffix.removeFilenameExtensions", false)) {
+                        String pageFileNameWithoutExtension = FilenameUtils.removeExtension(filename);
+                        cl.setREF(imagesPrefix + "/" + PathEncoder.encPath(getConfig().getContract() + "/" + pageFileNameWithoutExtension + suffix));
+                    } else {
+                        cl.setREF(imagesPrefix + "/" + PathEncoder.encPath(getConfig().getContract() + "/" + filename) + suffix);
+                    }
                 }
                 cl.setTYPE("URL");
                 version.setContentLocation(cl);


### PR DESCRIPTION
Prosím o začlenění těchto změn. Při importu z k3 balíků změny v kódu správně zapisují cestu k jpg souborům v foxml.
Změny v kódu jsou větve if-else větve, které odpovídají true/false nastavení convert.imageServerSuffix.removeFilenameExtensions=true v souboru migration.properties