### PR TITLE
Oprava buildu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,14 +16,13 @@
  */
 
 plugins {
-        id 'com.gradle.build-receipt' version '1.0'
+    id 'com.gradle.build-scan' version '1.0'
 }
 
-buildReceiptLicense {
-    agreementUrl = 'https://gradle.com/terms-of-service'
-    agree = 'yes'
+buildScan {
+    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+    licenseAgree = 'yes'
 }
-
 println "Building K4; please read BUILD-README.txt"
 
 apply plugin: 'distribution' // -> generate distributions


### PR DESCRIPTION
V současné době neprochází build z důvodu absence pluginu `com.gradle.build-receipt`. Pomůže tento plugin vyměnit za `com.gradle.build-scan`.



```
FAILURE: Build failed with an exception.

* Where:
Build file '/home/rumanekm/workspace/kramerius/build.gradle' line: 19

* What went wrong:
Plugin [id: 'com.gradle.build-receipt', version: '1.0'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Gradle Central Plugin Repository (plugin 'com.gradle.build-receipt' has no version '1.0' - see https://plugins.gradle.org/plugin/com.gradle.build-receipt for available versions)

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 5.095 secs
```