### PR TITLE
Multiple SLF4J bindings v lozích procesů

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ configurations {
 	}
 }
 
+
+configurations.all {
+    exclude module: 'slf4j-log4j12'
+}
+
+
 dependencies {
         // editor dependency
         editors group: "cz.incad.kramerius", name: "editor", version: "5.1.0", ext: "war"


### PR DESCRIPTION
V aktuálních buildech Krameria nám začala u všech procesů vyskakovat následující hlášky (a procesy padaly do stavu warning).

```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/local/tomcat/webapps/search/WEB-INF/lib/slf4j-jdk14-1.6.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/local/tomcat/webapps/search/WEB-INF/lib/slf4j-log4j12-1.7.12.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.JDK14LoggerFactory]
Sep 05, 2016 12:38:30 PM cz.incad.kramerius.processes.impl.ProcessStarter main
SEVERE: system error file contains errors
cz.incad.kramerius.processes.WarningException: system error file contains errors
	at cz.incad.kramerius.processes.impl.ProcessStarter.checkErrorFile(ProcessStarter.java:185)
	at cz.incad.kramerius.processes.impl.ProcessStarter.main(ProcessStarter.java:127)
```

Řešením je exclude na jednu knihovnu.