### PR TITLE
Příprava pro nasazení v Openshiftu

### DIFF
--- a/client/src/main/java/cz/incad/kramerius/client/RESTHelper.java
+++ b/client/src/main/java/cz/incad/kramerius/client/RESTHelper.java
@@ -201,8 +201,8 @@ public class RESTHelper {
         for (String val : nullfields) {
             if (val.contains(":")) {
                 String[] vals = val.split(":");
-                String lastModifKey = "Last Modified";
-                String lastFetchKey = "Last Fetched";
+                String lastModifKey = "Last-Modified";
+                String lastFetchKey = "Last-Fetched";
                 if (vals.length >= 2) {
                     if (vals[0].equals(lastModifKey)) {
                         resp.setHeader(lastModifKey, vals[1]);

--- a/common/src/main/java/cz/incad/kramerius/utils/conf/KConfiguration.java
+++ b/common/src/main/java/cz/incad/kramerius/utils/conf/KConfiguration.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
@@ -16,6 +17,7 @@ import java.util.logging.Level;
 import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.EnvironmentConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.configuration.reloading.FileChangedReloadingStrategy;
 
@@ -42,6 +44,7 @@ public class KConfiguration {
 
     private Configuration findAllConfigurations() throws IOException {
         CompositeConfiguration allConfiguration = new CompositeConfiguration();
+
         try {
             Enumeration<URL> resources = this.getClass().getClassLoader().getResources("res/configuration.properties");
             while (resources.hasMoreElements()) {
@@ -78,6 +81,16 @@ public class KConfiguration {
                     LOGGER.severe("ommiting '" + nextElement.getFile() + "'");
                 }
             }
+
+            EnvironmentConfiguration environmentConfiguration = new EnvironmentConfiguration();
+            for (Iterator it = environmentConfiguration.getKeys(); it.hasNext();) {
+                String key = (String)it.next();
+                String value = environmentConfiguration.getString(key);
+                key = key.replaceAll("_", ".");
+                key = key.replaceAll("\\.\\.", "__");
+                allConfiguration.setProperty(key, value);
+            }
+
             return allConfiguration;
         } catch (ConfigurationException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);

--- a/search/src/java/cz/incad/Kramerius/AbstractImageServlet.java
+++ b/search/src/java/cz/incad/Kramerius/AbstractImageServlet.java
@@ -168,8 +168,8 @@ public abstract class AbstractImageServlet extends GuiceServlet {
         Date lastModifiedDate = lastModified(pid, streamName);
         Calendar instance = Calendar.getInstance();
         instance.roll(Calendar.YEAR, 1);
-        resp.setDateHeader("Last Modified", lastModifiedDate.getTime());
-        resp.setDateHeader("Last Fetched", System.currentTimeMillis());
+        resp.setDateHeader("Last-Modified", lastModifiedDate.getTime());
+        resp.setDateHeader("Last-Fetched", System.currentTimeMillis());
         resp.setDateHeader("Expires", instance.getTime().getTime());
     }
 


### PR DESCRIPTION
Zkoušíme Kramerius provozovat v Openshiftu. Daří se nám to, ale museli jsme provést dvě malé modifikace:

1. umožnění konfigurace přes proměnné prostředí. Protože není možné mít v Openshiftu konfigurační direktivu s tečkou, je nutné místo teček používat podtržítko. (viz např. environment sekce Krameria v https://raw.githubusercontent.com/moravianlibrary/s2i-kramerius/master/docker-compose.yml).

2. Openshift používá reverzní proxy HAProxy, která je háklivá na validitu hlaviček. Opravil jsem Last-Modified a Last-Fetched (doplnil pomlčky).