### PR TITLE
Upravy z MZK

### DIFF
--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/virtualcollection/ClientVirtualCollections.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/virtualcollection/ClientVirtualCollections.java
@@ -52,7 +52,7 @@ public class ClientVirtualCollections {
             .getLogger(ClientVirtualCollections.class.getName());
 
     @Inject
-    @Named("fedora")
+    @Named("solr")
     CollectionsManager manager;
 
     @Inject


### PR DESCRIPTION
Verzia krameria 5.3.6 v klientovi neukazovala virt. zbierky a mali sme problém s indexovaním velkých PDF - pri veľkých PDF súboroch nám padala indexácia na "GC overhead limit exceeded", indexovanie pomocou súborov problém vyriešilo. 