### PR TITLE
Fix NoClassDefFoundError, close ceskaexpedice/kramerius#442

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/virtualcollections/CollectionUtils.java
+++ b/common/src/main/java/cz/incad/kramerius/virtualcollections/CollectionUtils.java
@@ -3,12 +3,10 @@ package cz.incad.kramerius.virtualcollections;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,29 +14,24 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.antlr.stringtemplate.StringTemplate;
 import org.antlr.stringtemplate.StringTemplateGroup;
 import org.antlr.stringtemplate.language.DefaultTemplateLexer;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.fedora.api.RelationshipTuple;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
 
 import cz.incad.kramerius.FedoraAccess;
 import cz.incad.kramerius.FedoraNamespaces;
 import cz.incad.kramerius.ProcessSubtreeException;
 import cz.incad.kramerius.TreeNodeProcessor;
-import cz.incad.kramerius.impl.FedoraAccessImpl;
 import cz.incad.kramerius.processes.impl.ProcessStarter;
 import cz.incad.kramerius.processes.utils.ProcessUtils;
 import cz.incad.kramerius.resourceindex.IResourceIndex;
 import cz.incad.kramerius.resourceindex.ResourceIndexService;
 import cz.incad.kramerius.utils.IOUtils;
-import cz.incad.kramerius.utils.XMLUtils;
 import cz.incad.kramerius.virtualcollections.Collection.Description;
 import cz.incad.kramerius.virtualcollections.impl.fedora.FedoraCollectionsManagerImpl;
 
@@ -98,7 +91,8 @@ public class CollectionUtils {
 
         Map<String, String> encodedTexts = new HashMap<String, String>();
         for (String k : plainTexts.keySet()) {
-            String encoded = Base64.getEncoder().encodeToString(plainTexts.get(k).getBytes("UTF-8"));
+            String encoded = Base64.encodeBase64String(plainTexts.get(k).getBytes("UTF-8"));;
+
             encodedTexts.put(k, encoded);
         }
         String pid = "vc:" + UUID.randomUUID().toString();


### PR DESCRIPTION
Odstranil jsem nativní volání Base64 enkodéru, který je součástí až Javy 8.

#442 je ukázka, že:
```
sourceCompatibility = 1.6
targetCompatibility= 1.6
```
pro zpětnou kompatibilitu nestačí, ohlídá to pouze language level (např. mi to nedovolí použít diamond operátor, který je až v Javě 7), ale nezakáže mi to použít metody a třídy z novějších verzí.

Správně nastavené IDE by mělo na použití nového API upozornit.
_______

Stejný problém je, že se na několika v místech používá API z Javy 7, takže Kramerius není možné nyní bezproblémově provozovat na Javě 6. Při jistých akcích to bude vyhazovat chyby  MethodNotFoundException or ClassNotFoundException.


> @pavel-stastny: Podpora a nepodpora javy 1.6 je problematicka. Radi bychom ale bohuzel existuji jeste instance kvuli kterym musime dodrzovat zpetnou kompatibilitu. (https://github.com/ceskaexpedice/kramerius/issues/306)

Je to ještě nutné? Stejně je už teď zpětná kompatibilita rozbitá.