### PR TITLE
Zpráva o právech v api/info, TLS pro imageserver, mw fix 

### DIFF
--- a/mw-process/src/main/java/cz/cas/lib/knav/ApplyMWUtils.java
+++ b/mw-process/src/main/java/cz/cas/lib/knav/ApplyMWUtils.java
@@ -27,6 +27,7 @@ import cz.incad.kramerius.service.impl.PolicyServiceImpl;
 import cz.incad.kramerius.utils.StringUtils;
 import cz.incad.kramerius.utils.XMLUtils;
 import cz.incad.kramerius.utils.conf.KConfiguration;
+import cz.incad.kramerius.ObjectPidsPath;
 
 /**
  * Apply MW Utility
@@ -141,6 +142,22 @@ public class ApplyMWUtils {
         ApplyMovingWall.LOGGER.info("Setting public | private flag for pid " + masterPid);
         ApplyMWUtils.process(fa, sa, masterPid, userValue, coll);
         Set<String> pids = fa.getPids(masterPid);
+
+        String[] root;
+        ObjectPidsPath[] path = sa.getPath(masterPid);
+        if(path == null) {
+            root = new String[1];
+            root[0] = masterPid;
+        } else {
+            root = path[path.length - 1].getPathFromRootToLeaf();
+        }
+        for (int i = 0; i < root.length; i++) {
+            if("policy:private".equals(disectFlagFromRELSEXT(root[i],fa))){
+                    pids.add(root[i]);
+                }
+            }
+
+
         for (String onePid : pids) {
             ApplyMWUtils.process(fa, sa, onePid, userValue, coll);
         }

--- a/mw-process/src/main/java/cz/cas/lib/knav/indexer/CollectPidForIndexing.java
+++ b/mw-process/src/main/java/cz/cas/lib/knav/indexer/CollectPidForIndexing.java
@@ -22,7 +22,7 @@ import cz.incad.kramerius.service.impl.IndexerProcessStarter.TokensFilter;
  */
 public class CollectPidForIndexing {
 
-    public static final int MAXIMUM_DOCUMENTS = 10000;
+    public static final int MAXIMUM_DOCUMENTS = 100;
 
     
     private List<String> collectedPids = new ArrayList<String>();

--- a/search/src/java/cz/incad/Kramerius/AbstractImageServlet.java
+++ b/search/src/java/cz/incad/Kramerius/AbstractImageServlet.java
@@ -1,20 +1,49 @@
 package cz.incad.Kramerius;
 
-import static cz.incad.kramerius.utils.IOUtils.copyStreams;
+import cz.incad.Kramerius.backend.guice.GuiceServlet;
+import cz.incad.kramerius.FedoraAccess;
+import cz.incad.kramerius.FedoraNamespaces;
+import cz.incad.kramerius.imaging.utils.ImageUtils;
+import cz.incad.kramerius.security.SecurityException;
+import cz.incad.kramerius.utils.FedoraUtils;
+import cz.incad.kramerius.utils.XMLUtils;
+import cz.incad.kramerius.utils.conf.KConfiguration;
+import cz.incad.kramerius.utils.imgs.ImageMimeType;
+import cz.incad.kramerius.utils.imgs.KrameriusImageSupport;
+import cz.incad.kramerius.utils.imgs.KrameriusImageSupport.ScalingMethod;
+import cz.incad.utils.SafeSimpleDateFormat;
+import org.antlr.stringtemplate.StringTemplate;
+import org.antlr.stringtemplate.StringTemplateGroup;
+import org.antlr.stringtemplate.language.DefaultTemplateLexer;
+import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpResponse;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.client.HttpAsyncClient;
+import org.apache.http.nio.client.methods.AsyncByteConsumer;
+import org.apache.http.nio.client.methods.HttpAsyncMethods;
+import org.apache.http.protocol.HttpContext;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
-import java.awt.Rectangle;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.xpath.XPathExpressionException;
+import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URLEncoder;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.sql.SQLException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -22,35 +51,9 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.xml.xpath.XPathExpressionException;
-
-import org.antlr.stringtemplate.StringTemplate;
-import org.antlr.stringtemplate.StringTemplateGroup;
-import org.antlr.stringtemplate.language.DefaultTemplateLexer;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-
-import com.google.inject.Inject;
-import com.google.inject.name.Named;
-
-import cz.incad.Kramerius.backend.guice.GuiceServlet;
-import cz.incad.kramerius.FedoraAccess;
-import cz.incad.kramerius.FedoraNamespaces;
-import cz.incad.kramerius.imaging.utils.ImageUtils;
-import cz.incad.kramerius.security.SecurityException;
-import cz.incad.kramerius.utils.FedoraUtils;
-import cz.incad.kramerius.utils.IOUtils;
-import cz.incad.kramerius.utils.RESTHelper;
-import cz.incad.kramerius.utils.XMLUtils;
-import cz.incad.kramerius.utils.conf.KConfiguration;
-import cz.incad.kramerius.utils.imgs.ImageMimeType;
-import cz.incad.kramerius.utils.imgs.KrameriusImageSupport;
-import cz.incad.kramerius.utils.imgs.KrameriusImageSupport.ScalingMethod;
-import cz.incad.utils.SafeSimpleDateFormat;
 
 public abstract class AbstractImageServlet extends GuiceServlet {
 
@@ -81,6 +84,9 @@ public abstract class AbstractImageServlet extends GuiceServlet {
     @Inject
     @Named("securedFedoraAccess")
     protected transient FedoraAccess fedoraAccess;
+
+    @Inject
+    protected transient HttpAsyncClient client;
 
     // @Inject
     // @Named("fedora3")
@@ -221,35 +227,52 @@ public abstract class AbstractImageServlet extends GuiceServlet {
 
     public abstract boolean turnOnIterateScaling();
 
-    public void copyFromImageServer(String urlString, HttpServletRequest req, HttpServletResponse resp)
-            throws MalformedURLException, IOException {
-        InputStream inputStream = null;
-        try {
-            HttpURLConnection con = (HttpURLConnection) RESTHelper.openConnection(urlString, "", "");
-            int responseCode = con.getResponseCode();
-            resp.setStatus(responseCode);
-            if (responseCode == 200) {
-                inputStream = con.getInputStream();
-                String contentType = con.getContentType();
 
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                copyStreams(inputStream, bos);
-                copyStreams(new ByteArrayInputStream(bos.toByteArray()),
-                        resp.getOutputStream());
+    public void copyFromImageServer(String urlString, final HttpServletResponse resp)
+            throws IOException {
+        final WritableByteChannel channel = Channels.newChannel(resp.getOutputStream());
 
-                resp.setContentType(contentType);
-                String headerFiled = con.getHeaderField("Cache-Control");
-                String lamodif = con.getHeaderField("Last-Modified");
-
-
-                resp.setHeader("Cache-Control", headerFiled);
-                resp.setHeader("Last-Modified", lamodif);
-                resp.setHeader("Access-Control-Allow-Origin", "*");
+        Future<Void> responseFuture = client.execute(HttpAsyncMethods.createGet(urlString), new AsyncByteConsumer<Void>() {
+            @Override
+            protected void onByteReceived(ByteBuffer byteBuffer, IOControl ioControl) throws IOException {
+                try {
+                    channel.write(byteBuffer);
+                } catch (IOException e) {
+                    if ("ClientAbortException".equals(e.getClass().getSimpleName())) {
+                        // Do nothing, request was cancelled by client. This is usual image viewers behavior.
+                    } else {
+                        throw new IOException(e);
+                    }
+                }
             }
-            
-            
-        } finally {
-            IOUtils.tryClose(inputStream);
+
+            @Override
+            protected void onResponseReceived(HttpResponse response) throws HttpException, IOException {
+                int statusCode = response.getStatusLine().getStatusCode();
+                resp.setStatus(statusCode);
+                if (statusCode == 200) {
+                    resp.setContentType(response.getEntity().getContentType().getValue());
+                    resp.setHeader("Access-Control-Allow-Origin", "*");
+                    Header cacheControl = response.getLastHeader("Cache-Control");
+                    if (cacheControl != null) resp.setHeader(cacheControl.getName(), cacheControl.getValue());
+                    Header lastModified = response.getLastHeader("Last-Modified");
+                    if (lastModified != null) resp.setHeader(lastModified.getName(), lastModified.getValue());
+
+                }
+            }
+
+            @Override
+            protected Void buildResult(HttpContext httpContext) throws Exception {
+                return null;
+            }
+        }, null);
+
+        try {
+            responseFuture.get(); // wait for request
+        } catch (InterruptedException e) {
+            throw new IOException(e.getMessage());
+        } catch (ExecutionException e) {
+            throw new IOException(e.getMessage());
         }
     }
 

--- a/search/src/java/cz/incad/Kramerius/backend/guice/BaseModule.java
+++ b/search/src/java/cz/incad/Kramerius/backend/guice/BaseModule.java
@@ -26,6 +26,8 @@ import cz.incad.kramerius.processes.impl.GCSchedulerImpl;
 import cz.incad.kramerius.processes.impl.ProcessSchedulerImpl;
 import cz.incad.kramerius.relation.RelationService;
 import cz.incad.kramerius.relation.impl.RelationServiceImpl;
+import cz.incad.kramerius.rest.api.guice.HttpAsyncClientLifeCycleHook;
+import cz.incad.kramerius.rest.api.guice.HttpAsyncClientProvider;
 import cz.incad.kramerius.security.SecuredFedoraAccessImpl;
 import cz.incad.kramerius.service.GoogleAnalytics;
 import cz.incad.kramerius.service.LifeCycleHook;
@@ -40,6 +42,7 @@ import cz.incad.kramerius.virtualcollections.Collection;
 import cz.incad.kramerius.virtualcollections.CollectionsManager;
 import cz.incad.kramerius.virtualcollections.impl.fedora.FedoraCollectionsManagerImpl;
 import cz.incad.kramerius.virtualcollections.impl.solr.SolrCollectionManagerImpl;
+import org.apache.http.nio.client.HttpAsyncClient;
 import org.ehcache.CacheManager;
 
 import javax.servlet.jsp.jstl.fmt.LocalizationContext;
@@ -100,9 +103,11 @@ public class BaseModule extends AbstractModule {
         bind(RepositoryUrlManager.class).to(CachingFedoraUrlManager.class).in(Scopes.SINGLETON);
 
         bind(CacheManager.class).toProvider(CacheProvider.class).in(Scopes.SINGLETON);
+        bind(HttpAsyncClient.class).toProvider(HttpAsyncClientProvider.class).in(Scopes.SINGLETON);
 
         Multibinder<LifeCycleHook> lfhooks = Multibinder.newSetBinder(binder(), LifeCycleHook.class);
         lfhooks.addBinding().to(CacheLifeCycleHook.class);
+        lfhooks.addBinding().to(HttpAsyncClientLifeCycleHook.class);
     }
 
     @Provides

--- a/search/src/java/cz/incad/Kramerius/imaging/DeepZoomServlet.java
+++ b/search/src/java/cz/incad/Kramerius/imaging/DeepZoomServlet.java
@@ -171,7 +171,7 @@ public class DeepZoomServlet extends AbstractImageServlet {
             StringTemplate dziUrl = stGroup().getInstanceOf("ndzi");
             if (urlForStream.endsWith("/")) urlForStream = urlForStream.substring(0, urlForStream.length()-1);
             dziUrl.setAttribute("url", urlForStream);
-            copyFromImageServer(dziUrl.toString(), null, resp);
+            copyFromImageServer(dziUrl.toString(), resp);
         }
     }
 
@@ -227,7 +227,7 @@ public class DeepZoomServlet extends AbstractImageServlet {
             tileUrl.setAttribute("url", dataStreamUrl);
             tileUrl.setAttribute("level", slevel);
             tileUrl.setAttribute("tile", stile);
-            copyFromImageServer(tileUrl.toString(), null, resp);
+            copyFromImageServer(tileUrl.toString(), resp);
         }
     }
 

--- a/search/src/java/cz/incad/Kramerius/imaging/IiifServlet.java
+++ b/search/src/java/cz/incad/Kramerius/imaging/IiifServlet.java
@@ -53,55 +53,59 @@ public class IiifServlet extends AbstractImageServlet {
 
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String requestURL = req.getRequestURL().toString();
-        String zoomUrl = DeepZoomServlet.disectZoom(requestURL);
-        StringTokenizer tokenizer = new StringTokenizer(zoomUrl, "/");
-        String pid = tokenizer.nextToken();
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException {
+        try {
+            String requestURL = req.getRequestURL().toString();
+            String zoomUrl = DeepZoomServlet.disectZoom(requestURL);
+            StringTokenizer tokenizer = new StringTokenizer(zoomUrl, "/");
+            String pid = tokenizer.nextToken();
 
-        //unescape PID
-        pid = URLDecoder.decode(pid, "UTF-8");
+            //unescape PID
+            pid = URLDecoder.decode(pid, "UTF-8");
 
-        if (!pid.matches("uuid:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")) {
-            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
-            return;
-        }
-
-        ObjectPidsPath[] paths = solrAccess.getPath(pid);
-        boolean permited = false;
-        for (ObjectPidsPath pth : paths) {
-            permited = this.actionAllowed.isActionAllowed(userProvider.get(), SecuredActions.READ.getFormalName(), pid, null, pth);
-            if (permited) break;
-        }
-
-        if (permited) {
-            try {
-                String u = IIIFUtils.iiifImageEndpoint(pid, this.fedoraAccess);
-                StringBuilder url = new StringBuilder(u);
-                while (tokenizer.hasMoreTokens()) {
-                    String nextToken = tokenizer.nextToken();
-                    url.append("/").append(nextToken);
-                    if ("info.json".equals(nextToken)) {
-                        resp.setContentType("application/ld+json");
-                        resp.setCharacterEncoding("UTF-8");
-                        HttpURLConnection con = (HttpURLConnection) RESTHelper.openConnection(url.toString(), "", "");
-                        InputStream inputStream = con.getInputStream();
-                        String json = IOUtils.toString(inputStream, Charset.defaultCharset());
-                        JSONObject object = new JSONObject(json);
-                        String urlRequest = req.getRequestURL().toString();
-                        object.put("@id", urlRequest.substring(0, urlRequest.lastIndexOf('/')));
-                        PrintWriter out = resp.getWriter();
-                        out.print(object.toString());
-                        out.flush();
-                        return;
-                    }
-                }
-                copyFromImageServer(url.toString(), req, resp);
-            } catch (JSONException e) {
-                LOGGER.log(Level.SEVERE, e.getMessage());
+            if (!pid.matches("uuid:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}")) {
+                resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
             }
-        } else {
-            resp.sendError(HttpServletResponse.SC_FORBIDDEN);
+
+            ObjectPidsPath[] paths = solrAccess.getPath(pid);
+            boolean permited = false;
+            for (ObjectPidsPath pth : paths) {
+                permited = this.actionAllowed.isActionAllowed(userProvider.get(), SecuredActions.READ.getFormalName(), pid, null, pth);
+                if (permited) break;
+            }
+
+            if (permited) {
+                try {
+                    String u = IIIFUtils.iiifImageEndpoint(pid, this.fedoraAccess);
+                    StringBuilder url = new StringBuilder(u);
+                    while (tokenizer.hasMoreTokens()) {
+                        String nextToken = tokenizer.nextToken();
+                        url.append("/").append(nextToken);
+                        if ("info.json".equals(nextToken)) {
+                            resp.setContentType("application/ld+json");
+                            resp.setCharacterEncoding("UTF-8");
+                            HttpURLConnection con = (HttpURLConnection) RESTHelper.openConnection(url.toString(), "", "");
+                            InputStream inputStream = con.getInputStream();
+                            String json = IOUtils.toString(inputStream, Charset.defaultCharset());
+                            JSONObject object = new JSONObject(json);
+                            String urlRequest = req.getRequestURL().toString();
+                            object.put("@id", urlRequest.substring(0, urlRequest.lastIndexOf('/')));
+                            PrintWriter out = resp.getWriter();
+                            out.print(object.toString());
+                            out.flush();
+                            return;
+                        }
+                    }
+                    copyFromImageServer(url.toString(),resp);
+                } catch (JSONException e) {
+                    LOGGER.log(Level.SEVERE, e.getMessage());
+                }
+            } else {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN);
+            }
+        } catch (IOException e) {
+            LOGGER.severe(e.getMessage());
         }
     }
 

--- a/search/src/java/cz/incad/Kramerius/imaging/ZoomifyServlet.java
+++ b/search/src/java/cz/incad/Kramerius/imaging/ZoomifyServlet.java
@@ -261,7 +261,7 @@ public class ZoomifyServlet extends AbstractImageServlet {
             StringTemplate dziUrl = stGroup().getInstanceOf("zoomify");
             if (urlForStream.endsWith("/")) urlForStream = urlForStream.substring(0, urlForStream.length()-1);
             dziUrl.setAttribute("url", urlForStream);
-            copyFromImageServer(dziUrl.toString(), null, resp);
+            copyFromImageServer(dziUrl.toString(), resp);
         }
     }
 
@@ -364,7 +364,7 @@ public class ZoomifyServlet extends AbstractImageServlet {
             tileUrl.setAttribute("x", x);
             tileUrl.setAttribute("y", y);
             tileUrl.setAttribute("ext", ext);
-            copyFromImageServer(tileUrl.toString(), null, resp);
+            copyFromImageServer(tileUrl.toString(), resp);
         }
     }
 }

--- a/search/src/java/labels.properties
+++ b/search/src/java/labels.properties
@@ -743,7 +743,7 @@ rights.action.show_statictics.formalName=DISPLAY STATISTICS
 rights.action.sort.formalName=SORT
 
 rights.action.show_print_menu.formalName=PRINT
-rights.action.show_info_text.formalName=SHOW ALTERNATIVE INFO TEXT
+rights.action.show_alternative_info_text.formalName=SHOW ALTERNATIVE INFO TEXT
 
 rights.action.show_client_pdf_menu.formalName=SHOW CLIENT PDF MENU
 rights.action.show_client_print_menu.formalName=SHOW CLIENT PRINT MENU
@@ -782,7 +782,7 @@ rights.action.show_client_print_menu = Show print menu
 rights.action.pdf_resource= Use pdf resource
 
 rights.action.criteria_rights_manage=Manage criteria parameters
-rights.action.show_info_text=Show alternative info text
+rights.action.show_alternative_info_text=Show alternative info text
 
 rights.global.actions.title=Global actions
 rights.collections.actions.title=Virtual collections' rights

--- a/search/src/java/labels_cs.properties
+++ b/search/src/java/labels_cs.properties
@@ -739,7 +739,7 @@ rights.action.show_statictics.formalName=ZOBRAZIT STATISTIKY
 rights.action.sort.formalName=T\u0158\u00CDDIT
 
 rights.action.show_print_menu.formalName=TISKNOUT
-rights.action.show_info_text.formalName=UKAZAT ALTERNATIVNI INFO TEXT
+rights.action.show_alternative_info_text.formalName=UKAZAT ALTERNATIVNI INFO TEXT
 
 rights.action.show_client_pdf_menu.formalName=SHOW CLIENT PDF MENU
 rights.action.show_client_print_menu.formalName=SHOW CLIENT PRINT MENU
@@ -790,7 +790,7 @@ rights.action.pdf_resource= Use pdf resource
 
 
 rights.action.criteria_rights_manage=Spravovat dodate\u010Dn\u00E9 podm\u00EDnky
-rights.action.show_info_text=Uk\u00E1zat alternativn\u00ED informativn\u00ED text
+rights.action.show_alternative_info_text=Uk\u00E1zat alternativn\u00ED informativn\u00ED text
 
 
 


### PR DESCRIPTION
#### Alternativní zpráva neveřejného dokumentu přes API
To co bylo implementováno  v https://github.com/ceskaexpedice/kramerius/pull/97 se nyní propisuje i do API.

#### TLS support pro imageserver
Mírně jsem přepsal kopírování streamu z imageserveru, protože v MZK přepneme imageserver na *https://*. Potřeboval jsem podporu `follow redirect`.

Kromě toho nově chytám *ClientAbortException*, kterou vyhodí Tomcat, když je request cancelled (prohlížečka obrázků se často rozhodne, že už dlaždici nepotřebuje a plevelilo nám to logy).


#### Moving wall fix
fixes #491

