### PR TITLE
Fix PDF s textovou vrstvou, filtr obálek, datum_str

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/security/impl/criteria/CoverAndContentFilter.java
+++ b/common/src/main/java/cz/incad/kramerius/security/impl/criteria/CoverAndContentFilter.java
@@ -1,0 +1,98 @@
+package cz.incad.kramerius.security.impl.criteria;
+
+import cz.incad.kramerius.FedoraAccess;
+import cz.incad.kramerius.FedoraNamespaceContext;
+import cz.incad.kramerius.security.EvaluatingResult;
+import cz.incad.kramerius.security.RightCriterium;
+import cz.incad.kramerius.security.RightCriteriumException;
+import cz.incad.kramerius.security.RightCriteriumPriorityHint;
+import cz.incad.kramerius.security.SecuredActions;
+import cz.incad.kramerius.security.SpecialObjects;
+import cz.incad.kramerius.utils.XMLUtils;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * CoverAndContentFilter
+ *
+ * Page types FrontCover and TableOfContents are copyright free (uncommercial and library usage)
+ *
+ * @author Martin Rumanek
+ */
+public class CoverAndContentFilter extends AbstractCriterium implements RightCriterium {
+
+    Logger LOGGER = java.util.logging.Logger.getLogger(CoverAndContentFilter.class.getName());
+
+    @Override
+    public EvaluatingResult evalute() throws RightCriteriumException {
+        try {
+            FedoraAccess fedoraAccess = getEvaluateContext().getFedoraAccess();
+            getEvaluateContext().getSolrAccess();
+            String pid = getEvaluateContext().getRequestedPid();
+            if (!pid.equals(SpecialObjects.REPOSITORY.getPid())) {
+                if ("page".equals(fedoraAccess.getKrameriusModelName(pid))) {
+                    Document mods = XMLUtils.parseDocument(
+                            fedoraAccess.getDataStream(pid, "BIBLIO_MODS"), true);
+                    return checkTypeElement(mods);
+                } else {
+                    return EvaluatingResult.NOT_APPLICABLE;
+                }
+            } else {
+                return EvaluatingResult.TRUE;
+            }
+
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            return EvaluatingResult.NOT_APPLICABLE;
+        } catch (SAXException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            return EvaluatingResult.NOT_APPLICABLE;
+        } catch (ParserConfigurationException e) {
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+            return EvaluatingResult.NOT_APPLICABLE;
+        }
+    }
+
+    private EvaluatingResult checkTypeElement(Document relsExt) throws IOException {
+        try {
+            XPathFactory xPathFactory = XPathFactory.newInstance();
+            XPath xpath = xPathFactory.newXPath();
+            xpath.setNamespaceContext(new FedoraNamespaceContext());
+            XPathExpression expr = xpath.compile("/mods:modsCollection/mods:mods/mods:part/@type");
+            String type = expr.evaluate(relsExt);
+            if (Arrays.asList("FrontCover", "TableOfContents", "FrontJacket").contains(type)) {
+                return EvaluatingResult.TRUE;
+            } else {
+                return EvaluatingResult.NOT_APPLICABLE;
+            }
+        } catch (XPathExpressionException e) {
+            throw new IOException(e);
+        }
+    }
+
+    @Override
+    public RightCriteriumPriorityHint getPriorityHint() {
+        return RightCriteriumPriorityHint.NORMAL;
+    }
+
+    @Override
+    public boolean isParamsNecessary() {
+        return false;
+    }
+
+    @Override
+    public SecuredActions[] getApplicableActions() {
+        return new SecuredActions[]{SecuredActions.READ};
+    }
+
+}

--- a/common/src/main/java/cz/incad/kramerius/security/impl/criteria/CriteriumsLoader.java
+++ b/common/src/main/java/cz/incad/kramerius/security/impl/criteria/CriteriumsLoader.java
@@ -30,7 +30,9 @@ public class CriteriumsLoader {
         return Arrays.asList(MovingWall.class.getName(), 
                 StrictIPAddresFilter.class.getName(), 
                 DefaultIPAddressFilter.class.getName(), 
-                PolicyFlag.class.getName());
+                PolicyFlag.class.getName(),
+                CoverAndContentFilter.class.getName()
+                );
     }
     
     public static List<RightCriterium> criteriums() throws InstantiationException, IllegalAccessException, ClassNotFoundException {

--- a/common/src/main/java/cz/incad/kramerius/security/res/criteriums
+++ b/common/src/main/java/cz/incad/kramerius/security/res/criteriums
@@ -5,6 +5,7 @@ cz.incad.kramerius.security.impl.criteria.Window
 cz.incad.kramerius.security.impl.criteria.StrictIPAddresFilter
 cz.incad.kramerius.security.impl.criteria.DefaultIPAddressFilter
 cz.incad.kramerius.security.impl.criteria.PolicyFlag
+cz.incad.kramerius.security.impl.criteria.CoverAndContentFilter
 cz.incad.kramerius.security.impl.criteria.DefaultDomainFilter
 cz.incad.kramerius.security.impl.criteria.StrictDomainFilter
 cz.incad.kramerius.security.impl.criteria.NegativeBenevolentModelFilter

--- a/common/src/main/java/cz/incad/kramerius/security/utils/SortingRightsUtils.java
+++ b/common/src/main/java/cz/incad/kramerius/security/utils/SortingRightsUtils.java
@@ -59,26 +59,24 @@ public class SortingRightsUtils {
             } 
         }
         
-        for (Iterator iterator = processing.iterator(); iterator.hasNext();) {
-            Right right = (Right) iterator.next();
-            switch(right.getCriteriumWrapper().getRightCriterium().getPriorityHint()) {
-                case MIN: {
-                    dynamicHintMin.add(right);
-                    iterator.remove();
+        for (Right right : processing) {
+            if (right.getCriteriumWrapper().getRightCriterium() != null) {
+                switch (right.getCriteriumWrapper().getRightCriterium().getPriorityHint()) {
+                    case MIN: {
+                        dynamicHintMin.add(right);
+                    }
+                    break;
+
+                    case NORMAL: {
+                        dynamicHintNormal.add(right);
+                    }
+                    break;
+
+                    case MAX: {
+                        dynamicHintMax.add(right);
+                    }
+                    break;
                 }
-                break;
-                
-                case NORMAL: {
-                    dynamicHintNormal.add(right);
-                    iterator.remove();
-                }
-                break;
-                
-                case MAX: {
-                    dynamicHintMax.add(right);
-                    iterator.remove();
-                }
-                break;
             }
         }
         

--- a/common/src/main/java/cz/knav/pdf/PdfTextUnderImage.java
+++ b/common/src/main/java/cz/knav/pdf/PdfTextUnderImage.java
@@ -131,7 +131,7 @@ public class PdfTextUnderImage {
 			}
 		}
         if (r == null) {
-            if (isSP(element)) {
+            if (isSP(element) || isHYP(element)) {
                 r = "Arial";
             } else {
                 throwPdfTextUnderImageException();
@@ -152,7 +152,7 @@ public class PdfTextUnderImage {
 			}
 		}
         if (r == null) {
-            if (isSP(element)) {
+            if (isSP(element) || isHYP(element)) {
                 r = 10f;
             } else {
                 throwPdfTextUnderImageException();

--- a/common/src/main/java/cz/knav/pdf/PdfTextUnderImage.java
+++ b/common/src/main/java/cz/knav/pdf/PdfTextUnderImage.java
@@ -246,10 +246,9 @@ public class PdfTextUnderImage {
 			}
 		}
 		if (e.hasAttribute(stylerefs)) {
-			String textStyleId = e.getAttribute(stylerefs);
-			int ix = textStyleId.lastIndexOf("font");
-			if (ix != -1) {
-				textStyleId = textStyleId.substring(ix);
+			String textStyleIdAttribute = e.getAttribute(stylerefs);
+
+			for (String textStyleId : textStyleIdAttribute.split(" ")) {
 		    	NodeList nodeList = alto.getElementsByTagName("TextStyle");
 		    	for (int i = 0; i < nodeList.getLength(); i++) {
 		    		Element textStyle = (Element) nodeList.item(i);

--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/AbstractFeederDecorator.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/AbstractFeederDecorator.java
@@ -48,9 +48,10 @@ public abstract class AbstractFeederDecorator extends AbstractDecorator {
         return new TokenizedPath(true, retvals);
     }
 
-    protected boolean mostDesirableOrNewest(TokenizedPath fctx) {
+    protected boolean mostDesirableOrNewestOrCustom(TokenizedPath fctx) {
         return fctx.getRestPath().get(0).equals("mostdesirable")
-                || fctx.getRestPath().get(0).equals("newest");
+                || fctx.getRestPath().get(0).equals("newest")
+                || fctx.getRestPath().get(0).equals("custom");
     }
 
 }

--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/SolrDateDecorate.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/SolrDateDecorate.java
@@ -78,7 +78,7 @@ public class SolrDateDecorate extends AbstractFeederDecorator {
     public boolean apply(JSONObject jsonObject, String context) {
         TokenizedPath fctx = super.feederContext(tokenize(context));
         if (fctx.isParsed()) {
-            return ((!fctx.getRestPath().isEmpty()) && mostDesirableOrNewest(fctx));
+            return ((!fctx.getRestPath().isEmpty()) && mostDesirableOrNewestOrCustom(fctx));
         } else
             return false;
     }

--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/SolrISSNDecorate.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/SolrISSNDecorate.java
@@ -75,7 +75,7 @@ public class SolrISSNDecorate extends AbstractFeederDecorator {
     public boolean apply(JSONObject jsonObject, String context) {
         TokenizedPath fctx = super.feederContext(tokenize(context));
         if (fctx.isParsed()) {
-            return ((!fctx.getRestPath().isEmpty()) && mostDesirableOrNewest(fctx));
+            return ((!fctx.getRestPath().isEmpty()) && mostDesirableOrNewestOrCustom(fctx));
         } else
             return false;
     }

--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/SolrLanguageDecorate.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/SolrLanguageDecorate.java
@@ -78,7 +78,7 @@ public class SolrLanguageDecorate extends AbstractFeederDecorator {
     public boolean apply(JSONObject jsonObject, String context) {
         TokenizedPath fctx = super.feederContext(tokenize(context));
         if (fctx.isParsed()) {
-            return ((!fctx.getRestPath().isEmpty()) && mostDesirableOrNewest(fctx));
+            return ((!fctx.getRestPath().isEmpty()) && mostDesirableOrNewestOrCustom(fctx));
         } else
             return false;
     }

--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/search/SearchResource.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/search/SearchResource.java
@@ -216,6 +216,9 @@ public class SearchResource {
             JSONObject jsonObject = changeJSONResult(rawString, uri, this.jsonDecoratorAggregates.getDecorators());
 
             return jsonObject.toString();
+        } catch (HttpResponseException e) {
+            LOGGER.log(Level.INFO, e.getMessage(), e);
+            throw new BadRequestException(e.getMessage());
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw new GenericApplicationException(e.getMessage());

--- a/search/src/java/labels.properties
+++ b/search/src/java/labels.properties
@@ -912,6 +912,8 @@ cz.incad.kramerius.security.impl.criteria.BenevolentMovingWall=Moving wall (bene
 cz.incad.kramerius.security.impl.criteria.Window=Window
 cz.incad.kramerius.security.impl.criteria.PolicyFlag=Public flag (kramerius:policy)
 cz.incad.kramerius.security.impl.criteria.SecuredStreams=Enum of secured streams
+cz.incad.kramerius.security.impl.criteria.CoverAndContentFilter=Cover and content filter (benevolent)
+
 cz.incad.kramerius.security.impl.criteria.none=No condition
 
 rights.changepswd.oldpswd=Old password

--- a/search/src/java/labels_cs.properties
+++ b/search/src/java/labels_cs.properties
@@ -914,6 +914,7 @@ cz.incad.kramerius.security.impl.criteria.BenevolentMovingWall=Pohybliv\u00E1 ze
 cz.incad.kramerius.security.impl.criteria.Window=Okno
 cz.incad.kramerius.security.impl.criteria.PolicyFlag=P\u0159\u00EDznak (kramerius:policy)
 cz.incad.kramerius.security.impl.criteria.SecuredStreams=V\u00FD\u010Det chr\u00E1n\u011Bn\u00FDch stream\u016F
+cz.incad.kramerius.security.impl.criteria.CoverAndContentFilter=Filtr obálek a obsahů (benevolentní)
 cz.incad.kramerius.security.impl.criteria.none=\u017D\u00E1dn\u00E1 podm\u00EDnka
 
 


### PR DESCRIPTION
PR obsahuje čtyři věci:

*Oprava PDF s textovou vrstvou*
Dřívější implementace předpokládala, že textstyle má vždy prefix `font`. Není to tak vždy. Mimo jiné pomlčka nemusí mít definovaný font vůbec.

*SOLR bad request*
Když je položený do API SOLR dotaz se špatnou syntaxí, tak se vracelo 500 i když to ve sktuečnosti byla chyba klienta (zanášelo to logy) - nyní se správně vrací 400.

*Filter obálek knih*
Služba obálky knih chtěli mít možnost z Krameria sklízet obálky a obsahy. Tyto typy stran jsou dle zákona autorsky volné, byl implementován benevolentní filtr, kterým toto zveřejní.

*Datum_str ve /feed/custom*
V API feed/custom nebyly PIDy obohacené o datum vydání. Fixnuto.

(Všechny změny jsou už nasazené v MZK na produkci)
