### PR TITLE
Login troubleshooting rework and useless code elimination

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/utils/RESTHelper.java
+++ b/common/src/main/java/cz/incad/kramerius/utils/RESTHelper.java
@@ -40,14 +40,7 @@ public class RESTHelper {
             HttpURLConnection httpUrl = (HttpURLConnection) uc;
             if (httpUrl != null) {
                 int responseCode = httpUrl.getResponseCode();
-                LOGGER.severe("status code "+responseCode);
-                
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                InputStream errorStream = httpUrl.getErrorStream();
-                if (errorStream != null) {
-                    IOUtils.copyStreams(errorStream, bos);
-                    LOGGER.severe(new String(bos.toByteArray(),"UTF-8"));
-                }
+                LOGGER.severe(urlString + " returned status code " + responseCode);
             }
             throw e;
         }

--- a/security-core/src/main/java/cz/incad/kramerius/security/jaas/K4LoginModule.java
+++ b/security-core/src/main/java/cz/incad/kramerius/security/jaas/K4LoginModule.java
@@ -87,8 +87,10 @@ public class K4LoginModule implements LoginModule {
                 this.logged = checkPswd(foundUser.getLoginname(), foundPswd, pswd);
             } else {
                 this.logged = false;
-                LOGGER.info("Login failed for user \"" + loginName + "\": invalid username or password!");
-                throw new FailedLoginException("Invalid username or password!");
+            }
+            if (!this.logged) {
+                  LOGGER.info("Login failed for user \"" + loginName + "\": invalid username or password!");
+                  throw new FailedLoginException("Invalid username or password!");
             }
         } catch (IOException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);


### PR DESCRIPTION
Minulý PR umožňoval vyhazovat FailedLoginException pouze je-li se uživatel zkoušel přihlášovat s chybným loginem, tento PR umožňuje vyhazovat výjimku i když se uživatel pokusí přihlásit s chybným heslem. Zároveň odstraní zbytečný výpis těla výjimky v RESTHelper.
@MartinRumanek prosím o revizi.