### PR TITLE
MW fix

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/processes/database/ProcessDatabaseUtils.java
+++ b/common/src/main/java/cz/incad/kramerius/processes/database/ProcessDatabaseUtils.java
@@ -144,6 +144,9 @@ public class ProcessDatabaseUtils {
                     buffer.append(parameters.get(i));
                     buffer.append((i == ll - 1) ? "" : ",");
                 }
+                if (buffer.length() > 4096){
+                    LOGGER.log(Level.SEVERE, "Parameters of process " + lp.getUUID() + " are too long and won't fit into the database.");
+                }
                 prepareStatement.setString(5, buffer.toString());
             } else {
                 prepareStatement.setString(5, null);

--- a/mw-process/src/main/java/cz/cas/lib/knav/indexer/CollectPidForIndexing.java
+++ b/mw-process/src/main/java/cz/cas/lib/knav/indexer/CollectPidForIndexing.java
@@ -22,7 +22,7 @@ import cz.incad.kramerius.service.impl.IndexerProcessStarter.TokensFilter;
  */
 public class CollectPidForIndexing {
 
-    public static final int MAXIMUM_DOCUMENTS = 100;
+    public static final int MAXIMUM_DOCUMENTS = 90;
 
     
     private List<String> collectedPids = new ArrayList<String>();


### PR DESCRIPTION
V pripade ze sa nazbiera 100 uuid na reindexaciu sa parametre tohoto procesu nezmestia do databaze. Preto znizenie poctu na 90 a zrozumitelnejsia sprava do logu pre pripad, ak by sa tento problem objavil pri planovani nejakeho ineho procesu.