### PR TITLE
replications: Removed unnecessary runtime name acquisition

### DIFF
--- a/processes/import/src/main/java/org/kramerius/replications/FirstPhase.java
+++ b/processes/import/src/main/java/org/kramerius/replications/FirstPhase.java
@@ -43,6 +43,8 @@ import cz.incad.kramerius.utils.IOUtils;
  */
 public class FirstPhase extends AbstractPhase  {
 
+    public static final String NAME = "FirstPhase";
+
     @Override
     public void start(String url, String userName, String pswd, String replicationCollections, String replicationImages) throws PhaseException {
         try {
@@ -119,4 +121,9 @@ public class FirstPhase extends AbstractPhase  {
         }
     }
     
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
 }

--- a/processes/import/src/main/java/org/kramerius/replications/K4ReplicationProcess.java
+++ b/processes/import/src/main/java/org/kramerius/replications/K4ReplicationProcess.java
@@ -95,7 +95,7 @@ public class K4ReplicationProcess {
     public static void restart(String processUUID, File previousProcessFolder, String url, String userName, String pswd, String replicateCollections, String replicateImages, Phase[] phases) throws IOException {
         try {
             for (Phase ph : phases) {
-                LOGGER.info("RESTARTING PHASE '"+ph.getClass().getName()+"'");
+                LOGGER.info("RESTARTING PHASE '"+ph.getName()+"'");
                 ph.restart(processUUID, previousProcessFolder, isPhaseCompleted(previousProcessFolder, ph), url, userName, pswd, replicateCollections, replicateImages);
                 phaseCompleted(ph);
             }
@@ -113,7 +113,7 @@ public class K4ReplicationProcess {
         try {
             ProcessStarter.updateName("Replikace '"+url+"'");
             for (Phase ph : phases) {
-                LOGGER.info("STARTING PHASE '"+ph.getClass().getName()+"'");
+                LOGGER.info("STARTING PHASE '"+ph.getName()+"'");
                 ph.start(url, userName, pswd, replicateCollections, replicateImages);
                 phaseCompleted(ph);
             }
@@ -133,39 +133,39 @@ public class K4ReplicationProcess {
     }
     
     static File phaseCompleted(Phase phase) throws IOException {
-        LOGGER.info("PHASE '"+phase.getClass().getName()+"' completed");
+        LOGGER.info("PHASE '"+phase.getName()+"' completed");
         File completedFile = phaseCompletedFile(phase);
         completedFile.createNewFile();
         return completedFile;
     }
 
     static File phaseFailed(Phase phase) throws IOException {
-        LOGGER.info("PHASE '"+phase.getClass().getName()+"' completed");
+        LOGGER.info("PHASE '"+phase.getName()+"' completed");
         File completedFile = phaseFailedFile(phase);
         completedFile.createNewFile();
         return completedFile;
     }
 
     static File phaseFailedFile(Phase phase) {
-        String clzName = phase.getClass().getName();
+        String clzName = phase.getName();
         File completedFile = new File(clzName+".failed");
         return completedFile;
     }
 
     static File phaseFailedFile(File rootFolder,Phase phase) {
-        String clzName = phase.getClass().getName();
+        String clzName = phase.getName();
         File completedFile = new File(rootFolder,clzName+".failed");
         return completedFile;
     }
 
     static File phaseCompletedFile(Phase phase) {
-        String clzName = phase.getClass().getName();
+        String clzName = phase.getName();
         File completedFile = new File(clzName+".completed");
         return completedFile;
     }
 
     static File phaseCompletedFile(File rootFolder, Phase phase) {
-        String clzName = phase.getClass().getName();
+        String clzName = phase.getName();
         File completedFile = new File(rootFolder,clzName+".completed");
         return completedFile;
     }

--- a/processes/import/src/main/java/org/kramerius/replications/Phase.java
+++ b/processes/import/src/main/java/org/kramerius/replications/Phase.java
@@ -49,4 +49,6 @@ public interface Phase {
     public void restart(String previousProcessUUID,File previousProcessRoot, boolean phaseCompleted, String url, String userName, String pswd,
                         String replicationCollections, String replicateImages) throws PhaseException;
 
+    public String getName();
+
 }

--- a/processes/import/src/main/java/org/kramerius/replications/SecondPhase.java
+++ b/processes/import/src/main/java/org/kramerius/replications/SecondPhase.java
@@ -73,6 +73,8 @@ import static java.util.concurrent.Executors.*;
 
 public class SecondPhase extends AbstractPhase  {
 
+    public static final String NAME = "SecondPhase";
+
     static java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(SecondPhase.class.getName());
 
 
@@ -330,6 +332,11 @@ public class SecondPhase extends AbstractPhase  {
             this.replicationImages = Boolean.parseBoolean(replicationImages);
             processIterate(url, userName, pswd);
         }
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     public boolean findPid(String pid) throws LexerException, IOException {

--- a/processes/import/src/main/java/org/kramerius/replications/ThirdPhase.java
+++ b/processes/import/src/main/java/org/kramerius/replications/ThirdPhase.java
@@ -53,6 +53,8 @@ import cz.incad.kramerius.utils.pid.LexerException;
 
 public class ThirdPhase extends AbstractPhase {
 
+    public static final String NAME = "ThirdPhase";
+
     static java.util.logging.Logger LOGGER = java.util.logging.Logger.getLogger(ThirdPhase.class.getName());
     
     @Override
@@ -134,7 +136,12 @@ public class ThirdPhase extends AbstractPhase {
             this.start(url, userName, pswd, replicationCollections, replicationImages);
         }
     }
-    
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
     static class Paths implements PidsListCollect {
         private List<String> foundPaths = new ArrayList<String>();
 

--- a/processes/import/src/main/java/org/kramerius/replications/ZeroPhase.java
+++ b/processes/import/src/main/java/org/kramerius/replications/ZeroPhase.java
@@ -22,6 +22,8 @@ public class ZeroPhase extends AbstractPhase {
 	public static final Logger LOGGER = Logger.getLogger(ZeroPhase.class.getName());
 	
 	
+	public static final String NAME = "ZeroPhase";
+
 	@Override
 	public void start(String url, String userName, String pswd, String replicationCollections, String replicationImages) throws PhaseException {
         validate(url, replicationCollections);
@@ -96,6 +98,11 @@ public class ZeroPhase extends AbstractPhase {
 	public void restart(String previousProcessUUID, File previousProcessRoot, boolean phaseCompleted, String url,
 			String userName, String pswd, String replicationCollections, String replicationImages) throws PhaseException {
         validate(url, replicationCollections);
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
 	}
 
 }


### PR DESCRIPTION
- Phase now contains getName() method to prevent runtime check which can be done compile-time