### PR TITLE
Issue moravianlibrary#223: Provide better error info when document is not present in Solr

### DIFF
--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/FeederSolrPolicyDecorate.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/feeder/decorators/FeederSolrPolicyDecorate.java
@@ -32,6 +32,11 @@ public class FeederSolrPolicyDecorate extends AbstractFeederDecorator {
             if(doc == null){
                 doc = this.solrMemo.askForIndexDocument(pid);
             }
+
+            if (doc == null) {
+                throw new IllegalStateException("Document could not be loaded from SOLR. Pid: " + pid);
+            }
+
             String policy = SOLRUtils.value(doc, "dostupnost", String.class);
             if(policy != null) {
                 jsonObject.put("policy", policy);


### PR DESCRIPTION
Původní řešení v případě nenalezení záznamu odesílalo `null` do `SOLRUtils.value()`, kde došlo k vyhození `throw new IllegalArgumentException("element must not be null");`, což komplikovalo určení původu chyby, protože neobsahovalo identifikátor dokumentu.

Úprava vyhazuje výjimku už v `FeederSolrPolicyDecorate` spolu s hodnotou `pid`.