### PR TITLE
#673 Remove unused import of nonexisting package in Java 1.8.0_201

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/service/impl/ExportServiceImpl.java
+++ b/common/src/main/java/cz/incad/kramerius/service/impl/ExportServiceImpl.java
@@ -1,7 +1,6 @@
 package cz.incad.kramerius.service.impl;
 
 
-import com.sun.javafx.collections.MappingChange;
 import cz.incad.kramerius.FedoraNamespaces;
 import cz.incad.kramerius.ObjectPidsPath;
 import cz.incad.kramerius.SolrAccess;


### PR DESCRIPTION
Import není v rámci třídy použit, takže build i nadále prochází.