### PR TITLE
Remove UTFSort non-existent method from JSP template

### DIFF
--- a/search/web/terms.jsp
+++ b/search/web/terms.jsp
@@ -19,15 +19,13 @@
             String i18nServlet = I18NServlet.i18nServlet(request) + "?action=bundle&lang="+lctx.getLocale().getLanguage()+"&country="+lctx.getLocale().getCountry()+"&name=labels";
             pageContext.setAttribute("i18nServlet", i18nServlet);
             String t = request.getParameter("t");
-            UTFSort utf_sort = new UTFSort();
-            utf_sort.init();
+            UTFSort utfSort = new UTFSort();
 
-            String term = utf_sort.translate(t);
+            String term = utfSort.translate(t);
             String including = request.getParameter("i");
             if (including==null){
                 including = "true";
             }
-            //term = java.net.URLEncoder.encode(term, "UTF-8");
             pageContext.setAttribute("term", term);
             pageContext.setAttribute("including", including);
 %>


### PR DESCRIPTION
@vlahoda omlouvám se, v JSP zůstal odkaz na odmazanou metodu. Začalo se to projevovat stacktracem při provozu.