### PR TITLE
Fix exceptions while logging of access

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/impl/FedoraAccessImpl.java
+++ b/common/src/main/java/cz/incad/kramerius/impl/FedoraAccessImpl.java
@@ -449,13 +449,8 @@ public class FedoraAccessImpl implements FedoraAccess {
     public InputStream getImageFULL(String pid) throws IOException {
         try {
             pid = makeSureObjectPid(pid);
-            if (this.accessLog != null && this.accessLog.isReportingAccess(pid,IMG_FULL_STREAM)) {
-                try {
-                        this.accessLog.reportAccess(pid,IMG_FULL_STREAM);
-                } catch (Exception e) {
-                        LOGGER.severe("cannot write statistic records");
-                        LOGGER.log(Level.SEVERE, e.getMessage(),e);
-                }
+            if (this.accessLog != null && this.accessLog.isReportingAccess(pid, IMG_FULL_STREAM)) {
+                reportAccess(pid, IMG_FULL_STREAM);
             }
 
             HttpURLConnection con = referencedDataStream(pid, IMG_FULL_STREAM);
@@ -534,25 +529,17 @@ public class FedoraAccessImpl implements FedoraAccess {
         }
     }
 
-    
-    
     @Override
     public boolean isObjectAvailable(String pid) throws IOException {
         try {
-            Document parseDocument = XMLUtils.parseDocument(getFedoraDataStreamsList(makeSureObjectPid(pid)), true);
+            XMLUtils.parseDocument(getFedoraDataStreamsList(makeSureObjectPid(pid)), true);
             return true;
-        } catch (ParserConfigurationException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new IOException(e);
-        } catch (SAXException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            throw new IOException(e);
-        } catch (LexerException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
+        } catch (ParserConfigurationException | SAXException | LexerException e) {
+            LOGGER.log(Level.WARNING, "Cannot parse XML document of " + pid, e);
             throw new IOException(e);
         } catch (FileNotFoundException e) {
             return false;
-        } 
+        }
     }
 
     @Override
@@ -758,7 +745,6 @@ public class FedoraAccessImpl implements FedoraAccess {
     private FedoraAPIM APIMport;
     private FedoraAPIA APIAport;
     private ObjectFactory of;
-
     @Override
     public FedoraAPIA getAPIA() {
         if (APIAport == null) {
@@ -821,7 +807,7 @@ public class FedoraAccessImpl implements FedoraAccess {
 //        if (treePredicates == null) {
 //            treePredicates = new ArrayList<String>();
 //            String prefix = KConfiguration.getInstance().getProperty("fedora.predicatesPrefix");
-//            
+//
 //            String[] preds = KConfiguration.getInstance().getPropertyList("fedora.treePredicates");
 //            for (String s : preds) {
 //                LOGGER.log(Level.INFO, prefix+s);
@@ -833,7 +819,6 @@ public class FedoraAccessImpl implements FedoraAccess {
     private List<String> getTreePredicates() {
         return Arrays.asList(KConfiguration.getInstance().getPropertyList("fedora.treePredicates"));
     }
-
     @Override
     public void processSubtree(String pid, TreeNodeProcessor processor) throws ProcessSubtreeException, IOException {
         try {
@@ -868,7 +853,7 @@ public class FedoraAccessImpl implements FedoraAccess {
         xpath.setNamespaceContext(new FedoraNamespaceContext());
         XPathExpression expr = xpath.compile("/rdf:RDF/rdf:Description/*");
         NodeList nodes = (NodeList) expr.evaluate(relsExt, XPathConstants.NODESET);
-        
+
         if(pidStack.contains(pid)){
             LOGGER.log(Level.WARNING, "Cyclic reference on "+pid);
             return breakProcessing;
@@ -970,28 +955,21 @@ public class FedoraAccessImpl implements FedoraAccess {
             throw new IOException(e);
         }
     }
-    
-    
-    
+
     @Override
     public InputStream getDataStream(String pid, String datastreamName) throws IOException {
         try {
             pid = makeSureObjectPid(pid);
-            if (this.accessLog != null && this.accessLog.isReportingAccess(pid,datastreamName)) {
-                try {
-                        this.accessLog.reportAccess(pid,datastreamName);
-                } catch (Exception e) {
-                    LOGGER.severe("cannot write statistic records");
-                    LOGGER.log(Level.SEVERE, e.getMessage(),e);
-                }
+            if (this.accessLog != null && this.accessLog.isReportingAccess(pid, datastreamName)) {
+                reportAccess(pid, datastreamName);
             }
-            
+
             HttpURLConnection con = referencedDataStream(pid, datastreamName);
             if (con == null) {
                 String streamLocation =  configuration.getFedoraHost() + "/get/" + pid + "/" + datastreamName;
                 con = (HttpURLConnection) openConnection(streamLocation, configuration.getFedoraUser(), configuration.getFedoraPass());
             }
-            
+
             con.connect();
             if (con.getResponseCode() == HttpURLConnection.HTTP_OK) {
                 InputStream thumbInputStream = con.getInputStream();
@@ -1021,7 +999,7 @@ public class FedoraAccessImpl implements FedoraAccess {
                     URLConnection directConnection = openConnection(dsLocation.getTextContent().trim(), "", "");
                     if (directConnection instanceof HttpURLConnection) {
                         con = (HttpURLConnection) directConnection;
-                    } 
+                    }
                 }
             }
         }
@@ -1194,5 +1172,11 @@ public class FedoraAccessImpl implements FedoraAccess {
         return (oneNode != null && oneNode.getNodeType() == Node.TEXT_NODE) ? ((Text) oneNode).getData() : "";
     }
 
-
+    private void reportAccess(String pid, String streamName) {
+        try {
+            this.accessLog.reportAccess(pid, streamName);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Can't write statistic records for " + pid + ", stream name: " + streamName, e);
+        }
+    }
 }

--- a/common/src/main/java/cz/incad/kramerius/utils/DCUtils.java
+++ b/common/src/main/java/cz/incad/kramerius/utils/DCUtils.java
@@ -19,7 +19,6 @@ import cz.incad.kramerius.document.model.DCConent;
  */
 public class DCUtils {
 
-    
     /**
      * Returns dc content from given document
      * @param doc parsed DC stream
@@ -46,7 +45,6 @@ public class DCUtils {
         if (identsFromDC != null) content.setIdentifiers(identsFromDC);
         
         return content;
-         
     }
 
     /**
@@ -70,9 +68,6 @@ public class DCUtils {
             return policy;
         } else return null;
     }
-
-
-
 
     /**
      * Returns title from dc stream
@@ -139,26 +134,25 @@ public class DCUtils {
         else return null;
     }
 
-    
     public static String[] identifierlsFromDC(org.w3c.dom.Document dc) {
         ArrayList<String> idents = findElmTexts(dc, "identifier");
         return (String[]) idents.toArray(new String[idents.size()]);
     }
     
     public static ArrayList<String> findElmTexts(org.w3c.dom.Document dc, String elmName) {
-        ArrayList<String> texts  = new ArrayList<String>();
-        Element documentElement = dc.getDocumentElement();
-        NodeList childNodes = documentElement.getChildNodes();
-        for (int i = 0; i < childNodes.getLength(); i++) {
-            Node item = childNodes.item(i);
-            if (item.getNodeType() == Node.ELEMENT_NODE) {
-                if (item.getLocalName().equals(elmName)) {
-                    texts.add(item.getTextContent().trim());
+        synchronized (dc) {
+            ArrayList<String> texts  = new ArrayList<String>();
+            Element documentElement = dc.getDocumentElement();
+            NodeList childNodes = documentElement.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node item = childNodes.item(i);
+                if (item.getNodeType() == Node.ELEMENT_NODE) {
+                    if (item.getLocalName().equals(elmName)) {
+                        texts.add(item.getTextContent().trim());
+                    }
                 }
             }
+            return texts;
         }
-        return texts;
     }
-
-
 }

--- a/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/pdf/AbstractPDFResource.java
+++ b/rest/src/main/java/cz/incad/kramerius/rest/api/k5/client/pdf/AbstractPDFResource.java
@@ -62,8 +62,7 @@ public class AbstractPDFResource {
         IMAGES, TEXT;
     }
 
-    public static final Logger LOGGER = Logger
-            .getLogger(AbstractPDFResource.class.getName());
+    public static final Logger LOGGER = Logger.getLogger(AbstractPDFResource.class.getName());
 
     @Inject
     @Named("TEXT")
@@ -149,7 +148,6 @@ public class AbstractPDFResource {
 
         File parentFile = null;
         File firstPageFile = null;
-        
         try {
             // abstract document
             parentFile = File.createTempFile("body", "pdf");
@@ -161,15 +159,9 @@ public class AbstractPDFResource {
             // most desirable
             for (String p : pids) {
                 this.mostDesirable.saveAccess(p, new Date());
-                try {
-                    this.statisticsAccessLog.reportAccess(p, FedoraUtils.IMG_FULL_STREAM, ReportedAction.PDF.name());
-                } catch (Exception e) {
-                    LOGGER.severe("cannot write statistic records");
-                    LOGGER.log(Level.SEVERE, e.getMessage(),e);
-                }
+                reportAccess(p);
             }
 
-            
             if (fp == FirstPage.IMAGES) {
                 this.imageFirstPage.selection(rdoc, fpageFos, pids, fmap);
             } else {
@@ -185,39 +177,24 @@ public class AbstractPDFResource {
         } finally {
             saveDeleteFile(parentFile, firstPageFile);
         }
-        
     }
 
     public File parent(String pid, int n, Rectangle rect, FirstPage fp) throws DocumentException,
-            IOException, NumberFormatException,
-            ProcessSubtreeException {
-
+            IOException, NumberFormatException, ProcessSubtreeException {
         FontMap fmap = new FontMap(deprectedService.fontsFolder());
-
-
         Map<String, AbstractObjectPath[]> pathsMap = solrAccess.getPaths(pid);
-
         ObjectPidsPath[] paths = (ObjectPidsPath[]) pathsMap.get(ObjectPidsPath.class.getName());
-        ObjectModelsPath[] models = (ObjectModelsPath[]) pathsMap.get(ObjectModelsPath.class.getName());;
-
         final ObjectPidsPath path = AbstractPDFResource.selectOnePath(pid, paths);
-        
+
         File parentFile = null;
         File firstPageFile = null;
         try {
-            
             PreparedDocument rdoc = this.documentService.buildDocumentAsFlat(path, pid, n, new int[] {(int)rect.getWidth(), (int)rect.getHeight()});
             checkRenderedPDFDoc(rdoc);
-            
-            
+
             this.mostDesirable.saveAccess(pid, new Date());
             for (AbstractPage p : rdoc.getPages()) {
-                try {
-                    this.statisticsAccessLog.reportAccess(p.getUuid(), FedoraUtils.IMG_FULL_STREAM, ReportedAction.PDF.name());
-                } catch (Exception e) {
-                    LOGGER.severe("cannot write statistic records");
-                    LOGGER.log(Level.SEVERE, e.getMessage(),e);
-                }
+                reportAccess(p.getUuid());
             }
 
             parentFile = File.createTempFile("body", "pdf");
@@ -246,7 +223,6 @@ public class AbstractPDFResource {
         }
     }
 
-
     private void checkRenderedPDFDoc(PreparedDocument rdoc) throws IOException {
         List<AbstractPage> pages = rdoc.getPages();
         for (AbstractPage apage : pages) {
@@ -256,7 +232,6 @@ public class AbstractPDFResource {
         }
     }
 
-
     private static void saveDeleteFile(File ... files) {
         for (File f : files) {
             if (f != null) {
@@ -265,10 +240,7 @@ public class AbstractPDFResource {
         }
     }
 
-
-
-    static ObjectPidsPath selectOnePath(String requestedPid,
-            ObjectPidsPath[] paths) {
+    static ObjectPidsPath selectOnePath(String requestedPid, ObjectPidsPath[] paths) {
         ObjectPidsPath path;
         if (paths.length > 0) {
             path = paths[0];
@@ -278,16 +250,13 @@ public class AbstractPDFResource {
         return path;
     }
 
-    static void mergeToOutput(OutputStream fos, File bodyFile,
-            File firstPageFile) throws IOException {
+    static void mergeToOutput(OutputStream fos, File bodyFile, File firstPageFile) throws IOException {
         PDFMergerUtility utility = new PDFMergerUtility();
         utility.addSource(firstPageFile);
         utility.addSource(bodyFile);
         utility.setDestinationStream(fos);
         utility.mergeDocuments();
     }
-
-    
 
     private boolean canBeRenderedAsPDF(String pid) throws IOException {
         ObjectPidsPath[] paths = solrAccess.getPath(pid);
@@ -299,8 +268,11 @@ public class AbstractPDFResource {
         return false;
     }
 
-
- 
-    
-    
+    private void reportAccess(String pid) {
+        try {
+            this.statisticsAccessLog.reportAccess(pid, FedoraUtils.IMG_FULL_STREAM, ReportedAction.PDF.name());
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Can't write statistic records for " + pid, e);
+        }
+    }
 }

--- a/search/src/java/cz/incad/Kramerius/imaging/IiifServlet.java
+++ b/search/src/java/cz/incad/Kramerius/imaging/IiifServlet.java
@@ -97,16 +97,7 @@ public class IiifServlet extends AbstractImageServlet {
                         String nextToken = tokenizer.nextToken();
                         url.append("/").append(nextToken);
                         if ("info.json".equals(nextToken)) {
-
-                            // report access
-                            try {
-                                this.aggregatedAccessLogs.reportAccess(pid, FedoraUtils.IMG_FULL_STREAM);
-                            } catch (Exception e) {
-                                LOGGER.severe("cannot write statistic records");
-                                LOGGER.log(Level.SEVERE, e.getMessage(),e);
-                            }
-
-
+                            reportAccess(pid);
                             resp.setContentType("application/ld+json");
                             resp.setCharacterEncoding("UTF-8");
                             HttpURLConnection con = (HttpURLConnection) RESTHelper.openConnection(url.toString(), "", "");
@@ -121,8 +112,6 @@ public class IiifServlet extends AbstractImageServlet {
                             return;
                         }
                     }
-
-
                     copyFromImageServer(url.toString(),resp);
                 } catch (JSONException e) {
                     LOGGER.log(Level.SEVERE, e.getMessage());
@@ -143,5 +132,13 @@ public class IiifServlet extends AbstractImageServlet {
     @Override
     public boolean turnOnIterateScaling() {
         return false;
+    }
+
+    private void reportAccess(String pid) {
+        try {
+            this.aggregatedAccessLogs.reportAccess(pid, FedoraUtils.IMG_FULL_STREAM);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Can't write statistic records for " + pid, e);
+        }
     }
 }

--- a/search/src/java/cz/incad/Kramerius/imaging/PrintPDFServlet.java
+++ b/search/src/java/cz/incad/Kramerius/imaging/PrintPDFServlet.java
@@ -139,23 +139,13 @@ public class PrintPDFServlet extends GuiceServlet {
             String pageSize = req.getParameter("pagesize");
             String imgop = req.getParameter("imgop");
 
-
             if (StringUtils.isAnyString(pid)) {
                 if (canBeRead(pid) && canBeRenderedAsPDF(pid)) {
-
                     Document document = new Document(Page.valueOf(pageSize).getRect());
                     ServletOutputStream sos = resp.getOutputStream();
                     PdfWriter.getInstance(document, sos);
                     document.open();
-
-                    try {
-                        this.statisticsAccessLog.reportAccess(pid, FedoraUtils.IMG_FULL_STREAM, ReportedAction.PRINT.name());
-                    } catch (Exception e) {
-                        LOGGER.severe("cannot write statistic records");
-                        LOGGER.log(Level.SEVERE, e.getMessage(),e);
-                    }
-
-                    
+                    reportAccess(pid);
                     File renderedFile = File.createTempFile("local", "print");
                     filesToDelete.add(renderedFile);
                     FileOutputStream fos = new FileOutputStream(renderedFile);
@@ -170,7 +160,6 @@ public class PrintPDFServlet extends GuiceServlet {
                                     - document.bottomMargin());
                     document.add(image);
                     document.close();
-                    
                 } else {
                     resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 }
@@ -184,10 +173,8 @@ public class PrintPDFServlet extends GuiceServlet {
                 for (int i = 0; i < pds.length; i++) {
                     if (!canBePDFRendered) canBePDFRendered = canBeRenderedAsPDF(pds[i]);
                 }
-                
-                
-                if (canBeRendered && canBePDFRendered) {
 
+                if (canBeRendered && canBePDFRendered) {
                     Document document = new Document(Page.valueOf(pageSize).getRect());
                     ServletOutputStream sos = resp.getOutputStream();
                     PdfWriter.getInstance(document, sos);
@@ -196,18 +183,10 @@ public class PrintPDFServlet extends GuiceServlet {
                     for (int i = 0; i < pds.length; i++) {
                         File nfile = File.createTempFile("local", "print");
                         filesToDelete.add(nfile);
-                
-                        try {
-                            this.statisticsAccessLog.reportAccess(pds[i], FedoraUtils.IMG_FULL_STREAM, ReportedAction.PRINT.name());
-                        } catch (Exception e) {
-                            LOGGER.severe("cannot write statistic records");
-                            LOGGER.log(Level.SEVERE, e.getMessage(),e);
-                        }
-
+                        reportAccess(pds[i]);
                         FileOutputStream fos = new FileOutputStream(nfile);
                         ImageOP.valueOf(imgop).imageData(this.fedoraAccess, pds[i], req, fos);
                         Image image = Image.getInstance(nfile.toURI().toURL());
-
                         image.scaleToFit(
                                 document.getPageSize().getWidth() - document.leftMargin()
                                         - document.rightMargin(),
@@ -236,6 +215,14 @@ public class PrintPDFServlet extends GuiceServlet {
         }
     }
 
+    private void reportAccess(String pid) {
+        try {
+            this.statisticsAccessLog.reportAccess(pid, FedoraUtils.IMG_FULL_STREAM, ReportedAction.PRINT.name());
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Can't write statistic records for " + pid, e);
+        }
+    }
+
     private boolean canBeRead(String pid) throws IOException {
         ObjectPidsPath[] paths = solrAccess.getPath(pid);
         for (ObjectPidsPath pth : paths) {
@@ -255,6 +242,4 @@ public class PrintPDFServlet extends GuiceServlet {
         }
         return false;
     }
-
-    
 }

--- a/search/src/java/cz/incad/Kramerius/imaging/ZoomifyServlet.java
+++ b/search/src/java/cz/incad/Kramerius/imaging/ZoomifyServlet.java
@@ -162,12 +162,7 @@ public class ZoomifyServlet extends AbstractImageServlet {
     }
 
     private void renderXMLDescriptor(String pid, HttpServletRequest req, HttpServletResponse resp) throws IOException, XPathExpressionException {
-        try {
-            this.aggregatedAccessLogs.reportAccess(pid, FedoraUtils.IMG_FULL_STREAM);
-        } catch (Exception e) {
-            LOGGER.severe("cannot write statistic records");
-            LOGGER.log(Level.SEVERE, e.getMessage(),e);
-        }
+        reportAccess(pid);
 
         setDateHaders(pid,FedoraUtils.IMG_FULL_STREAM, resp);
         setResponseCode(pid,FedoraUtils.IMG_FULL_STREAM, req, resp);
@@ -367,6 +362,14 @@ public class ZoomifyServlet extends AbstractImageServlet {
             tileUrl.setAttribute("y", y);
             tileUrl.setAttribute("ext", ext);
             copyFromImageServer(tileUrl.toString(), resp);
+        }
+    }
+
+    private void reportAccess(String pid) {
+        try {
+            this.aggregatedAccessLogs.reportAccess(pid, FedoraUtils.IMG_FULL_STREAM);
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Can't write statistic records for " + pid, e);
         }
     }
 }


### PR DESCRIPTION
Tento PR řeší chyby, na které jsme narazili při testování merge K5 a DNNT. Většina z nich byly chyby logování přistupů způsobené chybějící synchronizací parsování FOXML elementů v DNNTStatisticsAccessLogImpl a DCUtils a ukázaly se v provozu. A přidal jsem informativnější logování, aby bylo vidět u jakých dokumentů problémy vzníkají a tím bychom mohli opravovat připadné chyby v metadatech.