### PR TITLE
Fix frequent serialization exceptions

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/security/impl/criteria/BenevolentMovingWall.java
+++ b/common/src/main/java/cz/incad/kramerius/security/impl/criteria/BenevolentMovingWall.java
@@ -2,9 +2,12 @@ package cz.incad.kramerius.security.impl.criteria;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -23,63 +26,85 @@ import cz.incad.kramerius.ObjectPidsPath;
 import cz.incad.kramerius.security.impl.criteria.mw.DateLexer;
 import cz.incad.kramerius.security.impl.criteria.mw.DatesParser;
 
-public class BenevolentMovingWall extends AbstractCriterium implements
-        RightCriterium {
 
-    static java.util.logging.Logger LOGGER = java.util.logging.Logger
-            .getLogger(BenevolentMovingWall.class.getName());
+public class BenevolentMovingWall extends AbstractCriterium implements RightCriterium {
 
-    public static String[] MODS_XPATHS = {
+    private static final Logger LOGGER = Logger.getLogger(BenevolentMovingWall.class.getName());
+
+    private static final String[] MODS_DATE_XPATHS = {
+            "//mods:part/mods:date/text()",
             "//mods:originInfo/mods:dateIssued/text()",
-            "//mods:originInfo[@transliteration='publisher']/mods:dateIssued/text()",
-            "//mods:part/mods:date/text()" };
+            "//mods:originInfo/mods:dateIssued[@encoding='marc']/text()",
+            "//mods:originInfo[@transliteration='publisher']/mods:dateIssued/text()"
+    };
 
-
-    private XPathFactory xpfactory;
-
-    public BenevolentMovingWall() {
-        this.xpfactory = XPathFactory.newInstance();
-    }
+    private static final List<XPathExpression> MODS_DATE_XPATH_EXPRS = new ArrayList<XPathExpression>() {{
+        XPathFactory xpFactory = XPathFactory.newInstance();
+        XPath xpath = xpFactory.newXPath();
+        xpath.setNamespaceContext(new FedoraNamespaceContext());
+        for (String strExpr : MODS_DATE_XPATHS) {
+            try {
+                add(xpath.compile(strExpr));
+            } catch (XPathExpressionException e) {
+                LOGGER.log(Level.SEVERE, "Can't compile XPath expression \"" + strExpr + "\"!", e);
+            }
+        }
+    }};
 
     @Override
     public EvaluatingResultState evalute() throws RightCriteriumException {
-        int wallFromConf = Integer.parseInt((String) getObjects()[0]);
-        try {
-            ObjectPidsPath[] pathsToRoot = getEvaluateContext()
-                    .getPathsToRoot();
-            EvaluatingResultState result = null;
-            for (ObjectPidsPath pth : pathsToRoot) {
-                String[] pids = pth.getPathFromLeafToRoot();
-                for (String pid : pids) {
-
-                    if (pid.equals(SpecialObjects.REPOSITORY.getPid()))
-                        continue;
-                    Document biblioMods = getEvaluateContext()
-                            .getFedoraAccess().getBiblioMods(pid);
-                    // try all xpaths on mods
-                    for (String xp : MODS_XPATHS) {
-                        result = resolveInternal(wallFromConf, pid, xp,
-                                biblioMods);
-                        if (result != null)
-                            break;
-                    }
-
-                    // rozhodnul
-                    if (result != null) return result;
-                }
+        int configWall = Integer.parseInt((String) getObjects()[0]);
+        ObjectPidsPath[] pathsToRoot = getEvaluateContext().getPathsToRoot();
+        for (ObjectPidsPath pth : pathsToRoot) {
+            String[] pids = pth.getPathFromLeafToRoot();
+            for (String pid : pids) {
+                if (pid.equals(SpecialObjects.REPOSITORY.getPid()))
+                    continue;
+                EvaluatingResultState result = evaluateByModsDate(pid, configWall);
+                if (result != null)
+                    return result;
             }
-
-            return result != null ? result : EvaluatingResultState.NOT_APPLICABLE;
-        } catch (NumberFormatException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage());
-            return EvaluatingResultState.NOT_APPLICABLE;
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage());
-            return EvaluatingResultState.NOT_APPLICABLE;
-        } catch (XPathExpressionException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage());
-            return EvaluatingResultState.NOT_APPLICABLE;
         }
+        return EvaluatingResultState.NOT_APPLICABLE;
+    }
+
+    private EvaluatingResultState evaluateByModsDate(String pid, int configWall) {
+        try {
+            Document biblioMods = getEvaluateContext().getFedoraAccess().getBiblioMods(pid);
+            for (XPathExpression expr : MODS_DATE_XPATH_EXPRS) {
+                Date modsDate = getDate(expr, biblioMods);
+                EvaluatingResultState result = evaluate(modsDate, configWall);
+                if (result != null)
+                    return result;
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Can't get BIBLIO_MODS datastream of " + pid, e);
+        } catch (XPathExpressionException | TokenStreamException | RecognitionException |NumberFormatException e) {
+            LOGGER.log(Level.WARNING, "Can't parse date from BIBLIO_MODS datastream of " + pid, e);
+        }
+        return null;
+    }
+
+    private Date getDate(XPathExpression expr, Document bibilioMods)
+            throws XPathExpressionException, TokenStreamException, RecognitionException {
+        Object dateObj = expr.evaluate(bibilioMods, XPathConstants.NODE);
+        if (dateObj != null) {
+            String dateStr = ((Text) dateObj).getData();
+            DatesParser dateParse = new DatesParser(new DateLexer(new StringReader(dateStr)));
+            return dateParse.dates();
+        }
+        return null;
+    }
+
+    private EvaluatingResultState evaluate(Date date, int configWall) {
+        if (date == null)
+            return null;
+        Calendar calFromMetadata = Calendar.getInstance();
+        calFromMetadata.setTime(date);
+        Calendar calFromConf = Calendar.getInstance();
+        calFromConf.add(Calendar.YEAR, -1 * configWall);
+        return calFromMetadata.before(calFromConf) ?
+                EvaluatingResultState.TRUE : EvaluatingResultState.NOT_APPLICABLE;
     }
 
     @Override
@@ -89,52 +114,6 @@ public class BenevolentMovingWall extends AbstractCriterium implements
             case EXPECT_DATA_VALUE_DOESNTEXIST: return EvaluatingResultState.NOT_APPLICABLE;
         }
         return EvaluatingResultState.NOT_APPLICABLE;
-    }
-
-    public EvaluatingResultState resolveInternal(int wallFromConf, String pid,
-                                                 String xpath, Document xmlDoc) throws IOException,
-            XPathExpressionException {
-        if (pid.equals(SpecialObjects.REPOSITORY.getPid()))
-            return EvaluatingResultState.NOT_APPLICABLE;
-        return evaluateDoc(pid,wallFromConf, xmlDoc, xpath);
-    }
-
-    public EvaluatingResultState evaluateDoc(String pid, int wallFromConf, Document xmlDoc,
-                                             String xPathExpression) throws XPathExpressionException {
-        XPath xpath = xpfactory.newXPath();
-        xpath.setNamespaceContext(new FedoraNamespaceContext());
-        XPathExpression expr = xpath.compile(xPathExpression);
-        Object date = expr.evaluate(xmlDoc, XPathConstants.NODE);
-        if (date != null) {
-            String patt = ((Text) date).getData();
-
-            try {
-                DatesParser dateParse = new DatesParser(new DateLexer(
-                        new StringReader(patt)));
-                Date parsed = dateParse.dates();
-
-                Calendar calFromMetadata = Calendar.getInstance();
-                calFromMetadata.setTime(parsed);
-
-                Calendar calFromConf = Calendar.getInstance();
-                calFromConf.add(Calendar.YEAR, -1 * wallFromConf);
-
-                return calFromMetadata.before(calFromConf) ? EvaluatingResultState.TRUE
-                        : EvaluatingResultState.NOT_APPLICABLE;
-
-            } catch (RecognitionException e) {
-                LOGGER.log(Level.WARNING, e.getMessage() +" in object "+pid);
-                LOGGER.log(Level.WARNING, "Returning NOT_APPLICABLE");
-                return EvaluatingResultState.NOT_APPLICABLE;
-            } catch (TokenStreamException e) {
-                LOGGER.log(Level.WARNING, e.getMessage() +" in object "+pid);
-                LOGGER.log(Level.WARNING, "Returning NOT_APPLICABLE");
-                return EvaluatingResultState.NOT_APPLICABLE;
-            }
-
-        }
-
-        return null;
     }
 
     @Override

--- a/common/src/main/java/cz/incad/kramerius/security/impl/criteria/CoverAndContentFilter.java
+++ b/common/src/main/java/cz/incad/kramerius/security/impl/criteria/CoverAndContentFilter.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  */
 public class CoverAndContentFilter extends AbstractCriterium implements RightCriterium {
 
-    Logger LOGGER = java.util.logging.Logger.getLogger(CoverAndContentFilter.class.getName());
+    private static final Logger LOGGER = java.util.logging.Logger.getLogger(CoverAndContentFilter.class.getName());
     private static XPathExpression modsTypeExpr = null;
     private static final List<String> allowedPageTypes = Arrays.asList(
             "FrontCover", "TableOfContents", "FrontJacket", "TitlePage", "jacket"
@@ -51,14 +51,7 @@ public class CoverAndContentFilter extends AbstractCriterium implements RightCri
             } else {
                 return EvaluatingResultState.TRUE;
             }
-
-        } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            return EvaluatingResultState.NOT_APPLICABLE;
-        } catch (SAXException e) {
-            LOGGER.log(Level.SEVERE, e.getMessage(), e);
-            return EvaluatingResultState.NOT_APPLICABLE;
-        } catch (ParserConfigurationException e) {
+        } catch (IOException | SAXException | ParserConfigurationException e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
             return EvaluatingResultState.NOT_APPLICABLE;
         }
@@ -66,7 +59,8 @@ public class CoverAndContentFilter extends AbstractCriterium implements RightCri
 
     private EvaluatingResultState checkTypeElement(Document mods) throws IOException {
         try {
-            if (modsTypeExpr == null) initModsTypeExpr();
+            if (modsTypeExpr == null)
+                initModsTypeExpr();
             String type = modsTypeExpr.evaluate(mods);
             if (allowedPageTypes.contains(type)) {
                 return EvaluatingResultState.TRUE;
@@ -111,5 +105,4 @@ public class CoverAndContentFilter extends AbstractCriterium implements RightCri
     public SecuredActions[] getApplicableActions() {
         return new SecuredActions[]{SecuredActions.READ};
     }
-
 }


### PR DESCRIPTION
Kvůli loggeru v **CoverAndContentFilter.java** a XPathFactory v **BenevolentMovingWall.java** vznikaly chyby při pokusu o serializaci objektů.

```
26-Apr-2021 18:40:47.046 INFO [http-nio-8080-exec-12] org.ehcache.core.internal.resilience.LoggingRobustResilienceStrategy.recovered Ehcache key cz.incad.kramerius.security.impl.http.IsActionAllowedFromRequestCached$CacheKey@cbb2ac14 recovered from
	org.ehcache.core.spi.store.StoreAccessException: org.ehcache.spi.serialization.SerializerException: java.io.NotSerializableException: java.util.logging.Logger
		at org.ehcache.core.exceptions.StorePassThroughException.handleRuntimeException(StorePassThroughException.java:70)
		at org.ehcache.impl.internal.store.offheap.AbstractOffHeapStore.computeWithRetry(AbstractOffHeapStore.java:1109)
		at org.ehcache.impl.internal.store.offheap.AbstractOffHeapStore.put(AbstractOffHeapStore.java:316)
		at org.ehcache.impl.internal.store.tiering.TieredStore.put(TieredStore.java:138)
		at org.ehcache.core.Ehcache.put(Ehcache.java:198)
		at cz.incad.kramerius.security.impl.http.IsActionAllowedFromRequestCached.isAllowedInternalForFedoraDocuments(IsActionAllowedFromRequestCached.java:102)
		at cz.incad.kramerius.security.impl.http.IsActionAllowedFromRequest.isActionAllowed(IsActionAllowedFromRequest.java:58)
		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

```
26-Apr-2021 18:40:46.708 INFO [http-nio-8080-exec-7] org.ehcache.core.internal.resilience.LoggingRobustResilienceStrategy.recovered Ehcache key cz.incad.kramerius.security.impl.http.IsActionAllowedFromRequestCached$CacheKey@3f4ad323 recovered from
	org.ehcache.core.spi.store.StoreAccessException: org.ehcache.spi.serialization.SerializerException: java.io.NotSerializableException: org.apache.xpath.jaxp.XPathFactoryImpl
		at org.ehcache.core.exceptions.StorePassThroughException.handleRuntimeException(StorePassThroughException.java:70)
		at org.ehcache.impl.internal.store.offheap.AbstractOffHeapStore.computeWithRetry(AbstractOffHeapStore.java:1109)
		at org.ehcache.impl.internal.store.offheap.AbstractOffHeapStore.put(AbstractOffHeapStore.java:316)
		at org.ehcache.impl.internal.store.tiering.TieredStore.put(TieredStore.java:138)
		at org.ehcache.core.Ehcache.put(Ehcache.java:198)
		at cz.incad.kramerius.security.impl.http.IsActionAllowedFromRequestCached.isAllowedInternalForFedoraDocuments(IsActionAllowedFromRequestCached.java:102)
		at cz.incad.kramerius.security.impl.http.IsActionAllowedFromRequest.isActionAllowed(IsActionAllowedFromRequest.java:67)
```