### PR TITLE
Issue ceskaexpedice#597: adding option to ignore missing info about fonts - style and size

### DIFF
--- a/common/src/main/java/cz/knav/pdf/PdfTextUnderImage.java
+++ b/common/src/main/java/cz/knav/pdf/PdfTextUnderImage.java
@@ -9,6 +9,7 @@ import com.lowagie.text.pdf.ColumnText;
 import com.lowagie.text.pdf.PdfContentByte;
 import com.lowagie.text.pdf.PdfWriter;
 import cz.incad.kramerius.pdf.impl.AbstractPDFRenderSupport.ScaledImageOptions;
+import cz.incad.kramerius.utils.conf.KConfiguration;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -122,27 +123,39 @@ public class PdfTextUnderImage {
 	}
 
 	private String getFontFamily(Element element, org.w3c.dom.Document alto) {
-		String r = null;
-		Element textStyle = getTextStyle(element, alto);
-		if (textStyle != null) {
-			final String s = "FONTFAMILY";
-			if (textStyle.hasAttribute(s)) {
-				r = textStyle.getAttribute(s);
-			}
-		}
-        if (r == null) {
-            if (isSP(element) || isHYP(element)) {
-                r = "Arial";
-            } else {
-                throwPdfTextUnderImageException();
+            boolean ignoreSizeAndStyle = KConfiguration.getInstance()
+                        .getConfiguration()
+                        .getBoolean("pdfQueue.ignoreMissingSizeAndStyle", true);
+            String r = null;
+            Element textStyle = getTextStyle(element, alto);
+            if (textStyle != null) {
+                final String s = "FONTFAMILY";
+                    if (textStyle.hasAttribute(s)) {
+                        r = textStyle.getAttribute(s);
+                    }
             }
+            if (r == null) {
+                if (isSP(element) || isHYP(element)) {
+                    r = "Arial";
+                } else {
+                    if (ignoreSizeAndStyle) {
+                        r = "Arial";
+                    }
+                    else {
+                       throwPdfTextUnderImageException(); 
+                    }
+                }
+            }
+            return r;
         }
-		return r;
-	}
 
 	
 	private Float getFontSize(Element element, org.w3c.dom.Document alto, ScaledImageOptions options) {
 		//TODO: change it
+                boolean ignoreSizeAndStyle = KConfiguration.getInstance()
+                        .getConfiguration()
+                        .getBoolean("pdfQueue.ignoreMissingSizeAndStyle", true);
+                
 		Float r = null;
 		Element textStyle = getTextStyle(element, alto);
 		if (textStyle != null) {
@@ -151,18 +164,23 @@ public class PdfTextUnderImage {
 				r = new Float(pxOrPtOr(textStyle.getAttribute(s), true));
 			}
 		}
-        if (r == null) {
-            if (isSP(element) || isHYP(element)) {
-                r = 10f;
-            } else {
-                throwPdfTextUnderImageException();
-            }
-        }
+                if (r == null) {
+                    if (isSP(element) || isHYP(element)) {
+                        r = 10f;
+                    } else {
+                        if (ignoreSizeAndStyle) {
+                            r = 10f;
+                        }
+                        else {
+                            throwPdfTextUnderImageException();
+                        }
+                    }
+                }
 		
-		if (options.getScaleFactor() != 1.0) {
-			r = r * options.getScaleFactor();
+                if (options.getScaleFactor() != 1.0) {
+                    r = r * options.getScaleFactor();
 		}
-		return r;
+                return r;
 	}
 
 	private int getFontStyle(Element element, org.w3c.dom.Document alto) {


### PR DESCRIPTION
Když je v konfiguraci **pdfQueue.useAlto=true** a v souboru **ALTO chybí nepovinný element Styles**, tak **generování PDF** spadne a **vyhodí výjimku PdfTextUnderImageException**. Lze vyřešit vypnutím ALTA, ale vygeneruje se PDF bez textové horní vrstvy.

Vlevo ALTO bez elementu Styles (spadne), vpravo s elementem Styles (projde)
![styles](https://user-images.githubusercontent.com/44568581/160767443-1608cb8f-1943-4fc2-b599-5745981e3da4.png)

Pro úspěšné vygenerování PDF i s textovou vrstvou (**pdfQueue.useAlto=true**) je řešením defaultní ignorování chybějícího elementu Styles a dosazení defaultního fontu a jeho velikosti (již v kódu).

Kdo by přece jen chtěl, aby při chybějícím elementu Styles a generování PDF s ALTEM házelo chyby přidá do **configuration.properties**:
```
## V alto streamu chybi info o stylu fontu a jeho velikosti, pri pdfQueue.useAlto=true hazi exception PdfTextUnderImageException
## Da se ignorovat vyhazovani exception a nastavi se zakladni font a jeho velikost (defaultni hodnota pdfQueue.ignoreSizeAndStyle je true)
pdfQueue.ignoreMissingSizeAndStyle=false
```

