### PR TITLE
Issue ceskaexpedice#891: deleting from imageserver

### DIFF
--- a/common/src/main/java/cz/incad/kramerius/utils/StringUtils.java
+++ b/common/src/main/java/cz/incad/kramerius/utils/StringUtils.java
@@ -100,4 +100,19 @@ public class StringUtils {
     public static boolean isAnyString(String input) {
         return input != null && (!input.trim().equals(""));
     }
+    
+    
+    /**
+     * Gets string between two given strings
+     * @param text Given string
+     * @param start The first string (start)
+     * @param end The second string (end)
+     * @return String between the first and the second given strings
+     */
+    public static String getStringBetweenTwoStrings(String text, String start, String end) {
+        int startIndex = text.indexOf(start, 0) + start.length();
+        int endIndex = text.indexOf(end, startIndex);
+        
+        return text.substring(startIndex, endIndex);
+    }
 }

--- a/common/src/main/java/cz/incad/kramerius/utils/XMLUtils.java
+++ b/common/src/main/java/cz/incad/kramerius/utils/XMLUtils.java
@@ -408,4 +408,22 @@ public class XMLUtils {
          */
         public boolean acceptElement(Element element);
     }
+    
+    /**
+     * Gets text content of the first element which has desired name
+     * @param doc W3C document
+     * @param elementName Desired name of element from which we want to get text
+     * @return
+     */
+    public static String getTextOfElement(Document doc, String elementName) {
+        String text = null;
+        if (doc != null) {
+            NodeList nodeList = doc.getElementsByTagName(elementName);
+            if (nodeList.getLength() > 0) {
+                Node node = nodeList.item(0);
+                text = node.getTextContent();
+            }
+        }
+        return text;
+    }
 }

--- a/indexer/src/cz/incad/kramerius/indexer/SolrOperations.java
+++ b/indexer/src/cz/incad/kramerius/indexer/SolrOperations.java
@@ -543,7 +543,17 @@ public class SolrOperations {
             
             logger.log(Level.FINE, "indexDoc=\n{0}", docSrc);
             if (sb.indexOf("name=\"" + UNIQUEKEY) > 0) {
-                postData(config.getString("IndexBase") + "/update", docSrc, new StringBuilder());
+                try {
+                    postData(config.getString("IndexBase") + "/update", docSrc, new StringBuilder());
+                } 
+                catch (Exception ex) {
+                    if(config.getBoolean("indexer.continueOnError", false)) {
+                        logger.log(Level.SEVERE, "Error indexing pdf page " + i + ". Continuing.", ex);
+                    }
+                    else {
+                        throw ex;   
+                    }
+                }
                 updateTotal++;
             }
         }
@@ -573,7 +583,7 @@ public class SolrOperations {
                 + "\u0009\r\n"
                 + "\u0020-\uD7FF"
                 + "\uE000-\uFFFD"
-                + "\ud800\udc00-\udbff\udfff"
+                //+ "\ud800\udc00-\udbff\udfff"
                 + "]";
         return inString.replaceAll(xml10pattern, "");
         //return inString.replaceAll("[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F]", " ");


### PR DESCRIPTION
Mazání z imageserveru spíše pro KNAV.

Předpokládám, že cesta do imageserver se nachází mezi "FIF=" a "&":
```
<foxml:datastream ID="IMG_FULL" STATE="A" CONTROL_GROUP="E" VERSIONABLE="false">
<foxml:datastreamVersion ID="IMG_FULL.0" LABEL="" CREATED="2022-05-19T13:05:41.000Z" MIMETYPE="image/jpeg">
<foxml:contentLocation TYPE="URL" REF="http://localhost/cgi-bin/iipsrv.fcgi?FIF=/media/vg1-lv1/kramerius/k4test/iip-data/2022/05/19/aba007-00008r/uc_aba007-00008r_0001.jp2&WID=999999&CVT=jpeg"/>
</foxml:datastreamVersion>
</foxml:datastream>
```

Aby to fungovalo, je nutné přidat v konfiguraci Krameria configuration.properties: **delete.fromImageServer=true**

V testovacím Krameria KNAV otestováno a funguje to.