### PR TITLE
Optimalizácia K7 procesu RebuildProcessingIndex

### DIFF
--- a/shared/common/src/main/java/cz/incad/kramerius/resourceindex/ProcessingIndexRebuild.java
+++ b/shared/common/src/main/java/cz/incad/kramerius/resourceindex/ProcessingIndexRebuild.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/shared/common/src/main/java/cz/incad/kramerius/resourceindex/ProcessingIndexRebuild.java
+++ b/shared/common/src/main/java/cz/incad/kramerius/resourceindex/ProcessingIndexRebuild.java
@@ -43,22 +43,12 @@ import java.util.logging.Logger;
 public class ProcessingIndexRebuild {
     // Could be any number between 100 and 500,000. Lower the number, lower memory usage.
     // If it was too low, parallelization would be less effective.
-    // If it was too large, memory usage would slower overall execution, because of memory management.
+    // If it was too large, memory usage would slower overall execution, due to memory management.
     private static final int MAX_QUEUED_SUBMITTED_TASKS = 10000;
 
     public static final Logger LOGGER = Logger.getLogger(ProcessingIndexCheck.class.getName());
 
-    private static Unmarshaller unmarshaller = null;
-
-    static {
-        try {
-            JAXBContext jaxbContext = JAXBContext.newInstance(DigitalObject.class);
-            unmarshaller = jaxbContext.createUnmarshaller();
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Cannot init JAXB", e);
-            throw new RuntimeException(e);
-        }
-    }
+    private static final Unmarshaller unmarshaller = initUnmarshaller();
 
     private volatile static long counter = 0;
 
@@ -219,6 +209,16 @@ public class ProcessingIndexRebuild {
             throw new RepositoryException(e);
         } catch (ParserConfigurationException e) {
             throw new RepositoryException(e);
+        }
+    }
+
+    private static Unmarshaller initUnmarshaller() {
+        try {
+            JAXBContext jaxbContext = JAXBContext.newInstance(DigitalObject.class);
+            return jaxbContext.createUnmarshaller();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Cannot init JAXB", e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/shared/common/src/main/java/cz/incad/kramerius/resourceindex/ProcessingIndexRebuild.java
+++ b/shared/common/src/main/java/cz/incad/kramerius/resourceindex/ProcessingIndexRebuild.java
@@ -116,12 +116,22 @@ public class ProcessingIndexRebuild {
 
             @Override
             public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
-                return FileVisitResult.TERMINATE;
+                LOGGER.log(Level.SEVERE, "Error processing file: " + file.toString(), exc);
+
+                // This will allow the execution to continue uninterrupted,
+                // even in the event of encountering permission errors.
+                return FileVisitResult.CONTINUE;
             }
 
             @Override
             public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                return FileVisitResult.TERMINATE;
+                if (exc != null) {
+                    LOGGER.log(Level.SEVERE, "Error searching directory : " + dir.toString(), exc);
+                }
+
+                // This will allow the execution to continue uninterrupted,
+                // even in the event of encountering permission errors.
+                return FileVisitResult.CONTINUE;
             }
         });
 

--- a/shared/common/src/main/java/cz/incad/kramerius/resourceindex/ProcessingIndexRebuild.java
+++ b/shared/common/src/main/java/cz/incad/kramerius/resourceindex/ProcessingIndexRebuild.java
@@ -20,7 +20,6 @@ import cz.incad.kramerius.utils.FedoraUtils;
 import cz.incad.kramerius.utils.conf.KConfiguration;
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.checkerframework.checker.units.qual.C;
 import org.xml.sax.SAXException;
 
 import javax.xml.bind.JAXBContext;
@@ -29,10 +28,14 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.*;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -73,7 +76,7 @@ public class ProcessingIndexRebuild {
         }
 
         // ForkJoinPool is used to preserve parallelization.
-        // The default constructor of ForkJoinPool creates a pool with parallelism \
+        // The default constructor of ForkJoinPool creates a pool with parallelism
         // equal to Runtime.availableProcessors(), same as parallel streams.
         ForkJoinPool forkJoinPool = new ForkJoinPool();
 


### PR DESCRIPTION
Stará implementácia procesu RebuildProcesingIndex využívala na každých milión prejdených FOXML súborov približne 400 MB heap-u. Nová implementácia funguje na konštantom vyťažení pamäte, nezáleží na tom koľko súborov musí prejsť.

Vo funkcionalite sú dva rozdiely. Stará implementácia vedela detekovať symlink cykly a vedela sa na nich nezacykliť. Nová implementácia toto nevie, ale myslím, že je úplne zbytočné aby to vedela. Druhý rozdiel je, že keď som už implementoval FileVisitor, tak som ho naimplementoval tak, aby na permission denied chybách nepadal, ale aby ich iba zalogoval.

Tu je výstup z JProfiler-u po prejdení 40 miliónov FOXML. (Ku koncu sa garbage collector začal správať trošku inak ako väčšinu behu, a nevykresľuje to najlepšie také dlhé časové úseky. Ale využitie pamäte bolo konštantné.)
![graph_walk_file_tree](https://github.com/ceskaexpedice/kramerius/assets/65346739/79fd1eb9-aa8f-4ae6-a0d2-ab94b218baae)
